### PR TITLE
chore: fix scope object and rebundle docs

### DIFF
--- a/docs/thirdparty-openapi3-snippets.yaml
+++ b/docs/thirdparty-openapi3-snippets.yaml
@@ -937,8 +937,10 @@ components:
       type: object
       description: Scope + Account Identifier mapping for a Consent.
       example: |
-        { accountId: "dfsp.username.5678",
-          actions: [ "accounts.transfer", "accounts.getBalance" ] }
+        {
+          accountId: "dfsp.username.5678",
+          actions: [ "accounts.transfer", "accounts.getBalance" ]
+        }
       properties:
         accountId:
           $ref: '#/components/schemas/AccountAddress'

--- a/docs/thirdparty-openapi3-snippets.yaml
+++ b/docs/thirdparty-openapi3-snippets.yaml
@@ -937,13 +937,15 @@ components:
       type: object
       description: Scope + Account Identifier mapping for a Consent.
       properties:
-        scope:
-          $ref: '#/components/schemas/ConsentScopeType'
         accountId:
           $ref: '#/components/schemas/AccountAddress'
+        actions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConsentScopeType'
       required:
-        - scope
         - accountId
+        - actions
     ThirdpartyRequestsTransactionsIDAuthorizationsPostRequest:
       title: ThirdpartyRequestsTransactionsIDAuthorizationsPostRequest
       type: object

--- a/docs/thirdparty-openapi3-snippets.yaml
+++ b/docs/thirdparty-openapi3-snippets.yaml
@@ -936,6 +936,9 @@ components:
       title: Scope
       type: object
       description: Scope + Account Identifier mapping for a Consent.
+      example: |
+        { accountId: "dfsp.username.5678",
+          actions: [ "accounts.transfer", "accounts.getBalance" ] }
       properties:
         accountId:
           $ref: '#/components/schemas/AccountAddress'

--- a/thirdparty/openapi3/schemas/Scope.yaml
+++ b/thirdparty/openapi3/schemas/Scope.yaml
@@ -1,6 +1,9 @@
 title: Scope
 type: object
 description: Scope + Account Identifier mapping for a Consent.
+example: |
+  { accountId: "dfsp.username.5678",
+    actions: [ "accounts.transfer", "accounts.getBalance" ] }
 properties:
   accountId:
     $ref: './AccountAddress.yaml'

--- a/thirdparty/openapi3/schemas/Scope.yaml
+++ b/thirdparty/openapi3/schemas/Scope.yaml
@@ -2,10 +2,13 @@ title: Scope
 type: object
 description: Scope + Account Identifier mapping for a Consent.
 properties:
-  scope:
-    $ref: './ConsentScopeType.yaml'
   accountId:
     $ref: './AccountAddress.yaml'
+  actions:
+    type: array
+    items:
+      $ref: './ConsentScopeType.yaml'
 required:
-  - scope
   - accountId
+  - actions
+

--- a/thirdparty/openapi3/schemas/Scope.yaml
+++ b/thirdparty/openapi3/schemas/Scope.yaml
@@ -2,8 +2,10 @@ title: Scope
 type: object
 description: Scope + Account Identifier mapping for a Consent.
 example: |
-  { accountId: "dfsp.username.5678",
-    actions: [ "accounts.transfer", "accounts.getBalance" ] }
+  {
+    accountId: "dfsp.username.5678",
+    actions: [ "accounts.transfer", "accounts.getBalance" ]
+  }
 properties:
   accountId:
     $ref: './AccountAddress.yaml'


### PR DESCRIPTION
https://app.zenhub.com/workspaces/mojaloop-project-59edee71d1407922110cf083/issues/mojaloop/mojaloop/412
> POST /consents: body scope should be called action and should be an array instead of string

I think this bubbled up from examples in the pisp repo and from old sequence diagrams.
https://github.com/mojaloop/pisp/blob/7c1b878c720b64bc09f50f13962ebe24e117cc3c/docs/thirdparty-rest-v1.0-OpenApi.yaml#L304