### PR TITLE
chore: remove active from consent status enum

### DIFF
--- a/docs/thirdparty-openapi3-snippets.yaml
+++ b/docs/thirdparty-openapi3-snippets.yaml
@@ -711,11 +711,9 @@ components:
       title: ConsentStatusType
       type: string
       enum:
-        - ACTIVE
         - REVOKED
       description: |
         The status of the Consent.
-        - "ACTIVE" - The Consent is valid, and ready to be used by the PISP.
         - "REVOKED" - The Consent is no longer valid and has been revoked.
     Credential:
       title: Credential

--- a/thirdparty/openapi3/schemas/ConsentStatusType.yaml
+++ b/thirdparty/openapi3/schemas/ConsentStatusType.yaml
@@ -1,9 +1,7 @@
 title: ConsentStatusType
 type: string
 enum:
-  - ACTIVE
   - REVOKED
 description: |
   The status of the Consent.
-  - "ACTIVE" - The Consent is valid, and ready to be used by the PISP.
   - "REVOKED" - The Consent is no longer valid and has been revoked.


### PR DESCRIPTION
I long for the day when these snippets are set in stone and no longer require edits.