### PR TITLE
chore: add additional properties false for oneOf check

### DIFF
--- a/docs/thirdparty-openapi3-snippets.yaml
+++ b/docs/thirdparty-openapi3-snippets.yaml
@@ -431,6 +431,7 @@ components:
         - scopes
         - authChannels
         - callbackUri
+      additionalProperties: false
     ConsentRequestsIDPutResponseOTPAuth:
       title: ConsentRequestsIDPutResponseOTPAuth
       type: object
@@ -467,6 +468,7 @@ components:
         - authChannels
         - callbackUri
         - authToken
+      additionalProperties: false
     ConsentRequestsIDPutResponseWeb:
       title: ConsentRequestsIDPutResponseWeb
       type: object
@@ -504,6 +506,7 @@ components:
         - authChannels
         - callbackUri
         - authUri
+      additionalProperties: false
     ConsentRequestsIDPutResponseWebAuth:
       title: ConsentRequestsIDPutResponseWebAuth
       type: object
@@ -544,6 +547,7 @@ components:
         - callbackUri
         - authUri
         - authToken
+      additionalProperties: false
     ConsentRequestsPostRequest:
       title: ConsentRequestsPostRequest
       type: object

--- a/docs/thirdparty-openapi3-snippets.yaml
+++ b/docs/thirdparty-openapi3-snippets.yaml
@@ -409,8 +409,6 @@ components:
 
         Schema used in the request consent phase of the account linking OTP/SMS flow.
       properties:
-        id:
-          $ref: '#/components/schemas/ConsentRequestsPostRequest/properties/id'
         initiatorId:
           type: string
           description: The id of the PISP who will initiate transactions on a user's behalf.
@@ -426,7 +424,6 @@ components:
           type: string
           description: The callback uri that the user will be redirected to after completing the WEB auth channel.
       required:
-        - id
         - initiatorId
         - scopes
         - authChannels
@@ -442,8 +439,6 @@ components:
         the user is expected to prove their identity to the DFSP by passing a OTP
         or secret to the PISP.
       properties:
-        id:
-          $ref: '#/components/schemas/ConsentRequestsPostRequest/properties/id'
         initiatorId:
           type: string
           description: The id of the PISP who will initiate transactions on a user's behalf.
@@ -462,7 +457,6 @@ components:
           type: string
           description: The Auth token from the OTP or redirect to pisp app.
       required:
-        - id
         - initiatorId
         - scopes
         - authChannels
@@ -480,8 +474,6 @@ components:
         supposed user should be redirected. This URL should be a place where
         the user can prove their identity (e.g., by logging in).
       properties:
-        id:
-          $ref: '#/components/schemas/ConsentRequestsPostRequest/properties/id'
         initiatorId:
           type: string
           description: The id of the PISP who will initiate transactions on a user's behalf.
@@ -500,7 +492,6 @@ components:
           type: string
           description: The callback uri that the pisp app redirects to for user to complete their login.
       required:
-        - id
         - initiatorId
         - scopes
         - authChannels
@@ -517,8 +508,6 @@ components:
         the user is expected to prove their identity to the DFSP by passing a OTP
         or secret to the PISP.
       properties:
-        id:
-          $ref: '#/components/schemas/ConsentRequestsPostRequest/properties/id'
         initiatorId:
           type: string
           description: The id of the PISP who will initiate transactions on a user's behalf.
@@ -540,7 +529,6 @@ components:
           type: string
           description: The Auth token from the OTP or redirect to pisp app.
       required:
-        - id
         - initiatorId
         - scopes
         - authChannels

--- a/thirdparty/openapi3/schemas/ConsentRequestsIDPutResponseOTP.yaml
+++ b/thirdparty/openapi3/schemas/ConsentRequestsIDPutResponseOTP.yaml
@@ -28,3 +28,4 @@ required:
   - scopes
   - authChannels
   - callbackUri
+additionalProperties: false

--- a/thirdparty/openapi3/schemas/ConsentRequestsIDPutResponseOTP.yaml
+++ b/thirdparty/openapi3/schemas/ConsentRequestsIDPutResponseOTP.yaml
@@ -5,8 +5,6 @@ description: |
 
   Schema used in the request consent phase of the account linking OTP/SMS flow.
 properties:
-  id:
-    $ref: '../../../v1.0/openapi3/schemas/CorrelationId.yaml'
   initiatorId:
     type: string
     description: The id of the PISP who will initiate transactions on a user's behalf.
@@ -23,7 +21,6 @@ properties:
     type: string
     description: The callback uri that the user will be redirected to after completing the WEB auth channel.
 required:
-  - id
   - initiatorId
   - scopes
   - authChannels

--- a/thirdparty/openapi3/schemas/ConsentRequestsIDPutResponseOTPAuth.yaml
+++ b/thirdparty/openapi3/schemas/ConsentRequestsIDPutResponseOTPAuth.yaml
@@ -34,3 +34,4 @@ required:
   - authChannels
   - callbackUri
   - authToken
+additionalProperties: false

--- a/thirdparty/openapi3/schemas/ConsentRequestsIDPutResponseOTPAuth.yaml
+++ b/thirdparty/openapi3/schemas/ConsentRequestsIDPutResponseOTPAuth.yaml
@@ -7,8 +7,6 @@ description: |
   the user is expected to prove their identity to the DFSP by passing a OTP
   or secret to the PISP.
 properties:
-  id:
-    $ref: '../../../v1.0/openapi3/schemas/CorrelationId.yaml'
   initiatorId:
     type: string
     description: The id of the PISP who will initiate transactions on a user's behalf.
@@ -28,7 +26,6 @@ properties:
     type: string
     description: The Auth token from the OTP or redirect to pisp app.
 required:
-  - id
   - initiatorId
   - scopes
   - authChannels

--- a/thirdparty/openapi3/schemas/ConsentRequestsIDPutResponseWeb.yaml
+++ b/thirdparty/openapi3/schemas/ConsentRequestsIDPutResponseWeb.yaml
@@ -36,3 +36,4 @@ required:
   - authChannels
   - callbackUri
   - authUri
+additionalProperties: false

--- a/thirdparty/openapi3/schemas/ConsentRequestsIDPutResponseWeb.yaml
+++ b/thirdparty/openapi3/schemas/ConsentRequestsIDPutResponseWeb.yaml
@@ -8,8 +8,6 @@ description: |
   supposed user should be redirected. This URL should be a place where
   the user can prove their identity (e.g., by logging in).
 properties:
-  id:
-    $ref: '../../../v1.0/openapi3/schemas/CorrelationId.yaml'
   initiatorId:
     type: string
     description: The id of the PISP who will initiate transactions on a user's behalf.
@@ -30,7 +28,6 @@ properties:
     type: string
     description: The callback uri that the pisp app redirects to for user to complete their login.
 required:
-  - id
   - initiatorId
   - scopes
   - authChannels

--- a/thirdparty/openapi3/schemas/ConsentRequestsIDPutResponseWebAuth.yaml
+++ b/thirdparty/openapi3/schemas/ConsentRequestsIDPutResponseWebAuth.yaml
@@ -7,8 +7,6 @@ description: |
   the user is expected to prove their identity to the DFSP by passing a OTP
   or secret to the PISP.
 properties:
-  id:
-    $ref: '../../../v1.0/openapi3/schemas/CorrelationId.yaml'
   initiatorId:
     type: string
     description: The id of the PISP who will initiate transactions on a user's behalf.
@@ -32,7 +30,6 @@ properties:
     type: string
     description: The Auth token from the OTP or redirect to pisp app.
 required:
-  - id
   - initiatorId
   - scopes
   - authChannels

--- a/thirdparty/openapi3/schemas/ConsentRequestsIDPutResponseWebAuth.yaml
+++ b/thirdparty/openapi3/schemas/ConsentRequestsIDPutResponseWebAuth.yaml
@@ -39,3 +39,4 @@ required:
   - callbackUri
   - authUri
   - authToken
+additionalProperties: false


### PR DESCRIPTION
Need to add `additionalProperties: false` since some are a subset of others so that we can use `oneOf` 

Removed `id` that seems to have snuck into some yaml files but doesn't exist in sequence diagrams.