### PR TITLE
chore: remove credential field

### DIFF
--- a/docs/thirdparty-openapi3-snippets.yaml
+++ b/docs/thirdparty-openapi3-snippets.yaml
@@ -690,15 +690,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Scope'
-        credential:
-          $ref: '#/components/schemas/Credential'
-          nullable: true
       required:
         - id
         - scopes
         - participantId
         - initiatorId
-        - credential
     ConsentStatusType:
       title: ConsentStatusType
       type: string

--- a/thirdparty/openapi3/schemas/ConsentsPostRequest.yaml
+++ b/thirdparty/openapi3/schemas/ConsentsPostRequest.yaml
@@ -27,12 +27,8 @@ properties:
     type: array
     items:
       $ref: './Scope.yaml'
-  credential:
-    $ref: './Credential.yaml'
-    nullable: true
 required:
   - id
   - scopes
   - participantId
   - initiatorId
-  - credential


### PR DESCRIPTION
`POST /consents` `credential` is always null from my understanding. So we should just remove it.