### PR TITLE
chore: add additional properties false

### DIFF
--- a/docs/thirdparty-openapi3-snippets.yaml
+++ b/docs/thirdparty-openapi3-snippets.yaml
@@ -782,6 +782,7 @@ components:
       required:
         - payload
         - signature
+      additionalProperties: false
     CredentialChallengeUnsigned:
       title: CredentialChallengeSigned
       type: object
@@ -793,6 +794,7 @@ components:
           description: Base64 encoded binary of the challenge that must be answered by the PISP.
       required:
         - payload
+      additionalProperties: false
     CredentialType:
       title: CredentialType
       type: string
@@ -1011,6 +1013,7 @@ components:
         - status
         - challenge
         - payload
+      additionalProperties: false
     ThirdpartyRequestsTransactionsIDAuthorizationsPostRequest:
       title: ThirdpartyRequestsTransactionsIDAuthorizationsPostRequest
       type: object
@@ -1366,6 +1369,7 @@ components:
         - type
         - status
         - challenge
+      additionalProperties: false
     VerifiedCredential:
       title: VerifiedCredential
       type: object
@@ -1396,6 +1400,7 @@ components:
         - type
         - status
         - challenge
+      additionalProperties: false
 paths:
   /health:
     get:

--- a/thirdparty/openapi3/schemas/CredentialChallengeSigned.yaml
+++ b/thirdparty/openapi3/schemas/CredentialChallengeSigned.yaml
@@ -12,3 +12,4 @@ properties:
 required:
   - payload
   - signature
+additionalProperties: false

--- a/thirdparty/openapi3/schemas/CredentialChallengeUnsigned.yaml
+++ b/thirdparty/openapi3/schemas/CredentialChallengeUnsigned.yaml
@@ -8,3 +8,4 @@ properties:
     description: Base64 encoded binary of the challenge that must be answered by the PISP.
 required:
   - payload
+additionalProperties: false

--- a/thirdparty/openapi3/schemas/SignedCredential.yaml
+++ b/thirdparty/openapi3/schemas/SignedCredential.yaml
@@ -29,3 +29,4 @@ required:
   - status
   - challenge
   - payload
+additionalProperties: false

--- a/thirdparty/openapi3/schemas/UnsignedCredential.yaml
+++ b/thirdparty/openapi3/schemas/UnsignedCredential.yaml
@@ -21,3 +21,4 @@ required:
   - type
   - status
   - challenge
+additionalProperties: false

--- a/thirdparty/openapi3/schemas/VerifiedCredential.yaml
+++ b/thirdparty/openapi3/schemas/VerifiedCredential.yaml
@@ -27,3 +27,4 @@ required:
   - type
   - status
   - challenge
+additionalProperties: false


### PR DESCRIPTION
Add additionalProperties: false so oneOf is maintained since Unsigned is a subset of the others.