### PR TITLE
chore: fix parameters in api

### DIFF
--- a/docs/fspiop-rest-v1.0-openapi3-snippets.yaml
+++ b/docs/fspiop-rest-v1.0-openapi3-snippets.yaml
@@ -90,7 +90,7 @@ paths:
       responses:
         '200':
           description: Ok
-  /participants/Type/ID:
+  '/participants/{Type}/{ID}':
     parameters:
       - $ref: '#/components/parameters/Type'
       - $ref: '#/components/parameters/ID'
@@ -258,7 +258,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /participants/Type/ID/error:
+  '/participants/{Type}/{ID}/error':
     put:
       description: >-
         If the server is unable to find, create or delete the associated FSP of
@@ -308,7 +308,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /participants/Type/ID/SubId:
+  '/participants/{Type}/{ID}/{SubId}':
     parameters:
       - $ref: '#/components/parameters/Type'
       - $ref: '#/components/parameters/ID'
@@ -477,7 +477,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /participants/Type/ID/SubId/error:
+  '/participants/{Type}/{ID}/{SubId}/error':
     put:
       description: >-
         If the server is unable to find, create or delete the associated FSP of
@@ -578,7 +578,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /participants/ID:
+  '/participants/{ID}':
     put:
       description: >-
         The callback `PUT /participants/{ID}` is used to inform the client of
@@ -625,7 +625,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /participants/ID/error:
+  '/participants/{ID}/error':
     put:
       description: >-
         If there is an error during FSP information creation in the server, the
@@ -674,7 +674,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /parties/Type/ID:
+  '/parties/{Type}/{ID}':
     parameters:
       - $ref: '#/components/parameters/Type'
       - $ref: '#/components/parameters/ID'
@@ -756,7 +756,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /parties/Type/ID/error:
+  '/parties/{Type}/{ID}/error':
     put:
       description: >-
         If the server is unable to find Party information of the provided
@@ -806,7 +806,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /parties/Type/ID/SubId:
+  '/parties/{Type}/{ID}/{SubId}':
     parameters:
       - $ref: '#/components/parameters/Type'
       - $ref: '#/components/parameters/ID'
@@ -889,7 +889,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /parties/Type/ID/SubId/error:
+  '/parties/{Type}/{ID}/{SubId}/error':
     put:
       description: >-
         If the server is unable to find Party information of the provided
@@ -988,7 +988,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /transactionRequests/ID:
+  '/transactionRequests/{ID}':
     parameters:
       - $ref: '#/components/parameters/ID'
       - $ref: '#/components/parameters/Content-Type'
@@ -1070,7 +1070,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /transactionRequests/ID/error:
+  '/transactionRequests/{ID}/error':
     put:
       description: >-
         If the server is unable to find or create a transaction request, or
@@ -1168,7 +1168,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /quotes/ID:
+  '/quotes/{ID}':
     parameters:
       - $ref: '#/components/parameters/ID'
       - $ref: '#/components/parameters/Content-Type'
@@ -1248,7 +1248,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /quotes/ID/error:
+  '/quotes/{ID}/error':
     put:
       description: >-
         If the server is unable to find or create a quote, or some other
@@ -1298,7 +1298,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /authorizations/ID:
+  '/authorizations/{ID}':
     parameters:
       - $ref: '#/components/parameters/ID'
       - $ref: '#/components/parameters/Content-Type'
@@ -1411,7 +1411,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /authorizations/ID/error:
+  '/authorizations/{ID}/error':
     put:
       description: >-
         If the server is unable to find the transaction request, or another
@@ -1508,7 +1508,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /transfers/ID:
+  '/transfers/{ID}':
     parameters:
       - $ref: '#/components/parameters/ID'
       - $ref: '#/components/parameters/Content-Type'
@@ -1589,7 +1589,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /transfers/ID/error:
+  '/transfers/{ID}/error':
     put:
       description: >-
         If the server is unable to find or create a transfer, or another
@@ -1639,7 +1639,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /transactions/ID:
+  '/transactions/{ID}':
     parameters:
       - $ref: '#/components/parameters/ID'
       - $ref: '#/components/parameters/Content-Type'
@@ -1720,7 +1720,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /transactions/ID/error:
+  '/transactions/{ID}/error':
     put:
       description: >-
         If the server is unable to find or create a transaction, or another
@@ -1816,7 +1816,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /bulkQuotes/ID:
+  '/bulkQuotes/{ID}':
     parameters:
       - $ref: '#/components/parameters/ID'
       - $ref: '#/components/parameters/Content-Type'
@@ -1897,7 +1897,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /bulkQuotes/ID/error:
+  '/bulkQuotes/{ID}/error':
     put:
       description: >-
         If the server is unable to find or create a bulk quote, or another
@@ -1994,7 +1994,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /bulkTransfers/ID:
+  '/bulkTransfers/{ID}':
     parameters:
       - $ref: '#/components/parameters/ID'
       - $ref: '#/components/parameters/Content-Type'
@@ -2076,7 +2076,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /bulkTransfers/ID/error:
+  '/bulkTransfers/{ID}/error':
     put:
       description: >-
         If the server is unable to find or create a bulk transfer, or another

--- a/docs/fspiop-rest-v1.1-openapi3-snippets.yaml
+++ b/docs/fspiop-rest-v1.1-openapi3-snippets.yaml
@@ -48,7 +48,7 @@ paths:
       responses:
         '200':
           description: Ok
-  /participants/Type/ID:
+  '/participants/{Type}/{ID}':
     parameters:
       - $ref: '#/components/parameters/Type'
       - $ref: '#/components/parameters/ID'
@@ -217,7 +217,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /participants/Type/ID/error:
+  '/participants/{Type}/{ID}/error':
     put:
       description: >-
         If the server is unable to find, create or delete the associated FSP of
@@ -267,7 +267,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /participants/Type/ID/SubId:
+  '/participants/{Type}/{ID}/{SubId}':
     parameters:
       - $ref: '#/components/parameters/Type'
       - $ref: '#/components/parameters/ID'
@@ -437,7 +437,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /participants/Type/ID/SubId/error:
+  '/participants/{Type}/{ID}/{SubId}/error':
     put:
       description: >-
         If the server is unable to find, create or delete the associated FSP of
@@ -538,7 +538,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /participants/ID:
+  '/participants/{ID}':
     put:
       description: >-
         The callback `PUT /participants/{ID}` is used to inform the client of
@@ -585,7 +585,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /participants/ID/error:
+  '/participants/{ID}/error':
     put:
       description: >-
         If there is an error during FSP information creation in the server, the
@@ -634,7 +634,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /parties/Type/ID:
+  '/parties/{Type}/{ID}':
     parameters:
       - $ref: '#/components/parameters/Type'
       - $ref: '#/components/parameters/ID'
@@ -716,7 +716,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /parties/Type/ID/error:
+  '/parties/{Type}/{ID}/error':
     put:
       description: >-
         If the server is unable to find Party information of the provided
@@ -766,7 +766,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /parties/Type/ID/SubId:
+  '/parties/{Type}/{ID}/{SubId}':
     parameters:
       - $ref: '#/components/parameters/Type'
       - $ref: '#/components/parameters/ID'
@@ -849,7 +849,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /parties/Type/ID/SubId/error:
+  '/parties/{Type}/{ID}/{SubId}/error':
     put:
       description: >-
         If the server is unable to find Party information of the provided
@@ -948,7 +948,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /transactionRequests/ID:
+  '/transactionRequests/{ID}':
     parameters:
       - $ref: '#/components/parameters/ID'
       - $ref: '#/components/parameters/Content-Type'
@@ -1030,7 +1030,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /transactionRequests/ID/error:
+  '/transactionRequests/{ID}/error':
     put:
       description: >-
         If the server is unable to find or create a transaction request, or
@@ -1128,7 +1128,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /quotes/ID:
+  '/quotes/{ID}':
     parameters:
       - $ref: '#/components/parameters/ID'
       - $ref: '#/components/parameters/Content-Type'
@@ -1208,7 +1208,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /quotes/ID/error:
+  '/quotes/{ID}/error':
     put:
       description: >-
         If the server is unable to find or create a quote, or some other
@@ -1258,7 +1258,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /authorizations/ID:
+  '/authorizations/{ID}':
     parameters:
       - $ref: '#/components/parameters/ID'
       - $ref: '#/components/parameters/Content-Type'
@@ -1371,7 +1371,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /authorizations/ID/error:
+  '/authorizations/{ID}/error':
     put:
       description: >-
         If the server is unable to find the transaction request, or another
@@ -1468,7 +1468,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /transfers/ID:
+  '/transfers/{ID}':
     parameters:
       - $ref: '#/components/parameters/ID'
       - $ref: '#/components/parameters/Content-Type'
@@ -1589,7 +1589,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /transfers/ID/error:
+  '/transfers/{ID}/error':
     put:
       description: >-
         If the server is unable to find or create a transfer, or another
@@ -1639,7 +1639,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /transactions/ID:
+  '/transactions/{ID}':
     parameters:
       - $ref: '#/components/parameters/ID'
       - $ref: '#/components/parameters/Content-Type'
@@ -1720,7 +1720,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /transactions/ID/error:
+  '/transactions/{ID}/error':
     put:
       description: >-
         If the server is unable to find or create a transaction, or another
@@ -1816,7 +1816,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /bulkQuotes/ID:
+  '/bulkQuotes/{ID}':
     parameters:
       - $ref: '#/components/parameters/ID'
       - $ref: '#/components/parameters/Content-Type'
@@ -1897,7 +1897,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /bulkQuotes/ID/error:
+  '/bulkQuotes/{ID}/error':
     put:
       description: >-
         If the server is unable to find or create a bulk quote, or another
@@ -1994,7 +1994,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /bulkTransfers/ID:
+  '/bulkTransfers/{ID}':
     parameters:
       - $ref: '#/components/parameters/ID'
       - $ref: '#/components/parameters/Content-Type'
@@ -2076,7 +2076,7 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
-  /bulkTransfers/ID/error:
+  '/bulkTransfers/{ID}/error':
     put:
       description: >-
         If the server is unable to find or create a bulk transfer, or another

--- a/fspiop/v1_0/openapi3/openapi.yaml
+++ b/fspiop/v1_0/openapi3/openapi.yaml
@@ -90,63 +90,63 @@ paths:
       responses:
         200:
           description: Ok
-  /participants/Type/ID:
+  /participants/{Type}/{ID}:
     $ref: 'paths/participants_Type_ID.yaml'
-  /participants/Type/ID/error:
+  /participants/{Type}/{ID}/error:
     $ref: 'paths/participants_Type_ID_error.yaml'
-  /participants/Type/ID/SubId:
+  /participants/{Type}/{ID}/{SubId}:
     $ref: 'paths/participants_Type_ID_SubId.yaml'
-  /participants/Type/ID/SubId/error:
+  /participants/{Type}/{ID}/{SubId}/error:
     $ref: 'paths/participants_Type_ID_SubId_error.yaml'
   /participants:
     $ref: 'paths/participants.yaml'
-  /participants/ID:
+  /participants/{ID}:
     $ref: 'paths/participants_ID.yaml'
-  /participants/ID/error:
+  /participants/{ID}/error:
     $ref: 'paths/participants_ID_error.yaml'
-  /parties/Type/ID:
+  /parties/{Type}/{ID}:
     $ref: 'paths/parties_Type_ID.yaml'
-  /parties/Type/ID/error:
+  /parties/{Type}/{ID}/error:
     $ref: 'paths/parties_Type_ID_error.yaml'
-  /parties/Type/ID/SubId:
+  /parties/{Type}/{ID}/{SubId}:
     $ref: 'paths/parties_Type_ID_SubId.yaml'
-  /parties/Type/ID/SubId/error:
+  /parties/{Type}/{ID}/{SubId}/error:
     $ref: 'paths/parties_Type_ID_SubId_error.yaml'
   /transactionRequests:
     $ref: 'paths/transactionRequests.yaml'
-  /transactionRequests/ID:
+  /transactionRequests/{ID}:
     $ref: 'paths/transactionRequests_ID.yaml'
-  /transactionRequests/ID/error:
+  /transactionRequests/{ID}/error:
     $ref: 'paths/transactionRequests_ID_error.yaml'
   /quotes:
     $ref: 'paths/quotes.yaml'
-  /quotes/ID:
+  /quotes/{ID}:
     $ref: 'paths/quotes_ID.yaml'
-  /quotes/ID/error:
+  /quotes/{ID}/error:
     $ref: 'paths/quotes_ID_error.yaml'
-  /authorizations/ID:
+  /authorizations/{ID}:
     $ref: 'paths/authorizations_ID.yaml'
-  /authorizations/ID/error:
+  /authorizations/{ID}/error:
     $ref: 'paths/authorizations_ID_error.yaml'
   /transfers:
     $ref: 'paths/transfers.yaml'
-  /transfers/ID:
+  /transfers/{ID}:
     $ref: 'paths/transfers_ID.yaml'
-  /transfers/ID/error:
+  /transfers/{ID}/error:
     $ref: 'paths/transfers_ID_error.yaml'
-  /transactions/ID:
+  /transactions/{ID}:
     $ref: 'paths/transactions_ID.yaml'
-  /transactions/ID/error:
+  /transactions/{ID}/error:
     $ref: 'paths/transactions_ID_error.yaml'
   /bulkQuotes:
     $ref: 'paths/bulkQuotes.yaml'
-  /bulkQuotes/ID:
+  /bulkQuotes/{ID}:
     $ref: 'paths/bulkQuotes_ID.yaml'
-  /bulkQuotes/ID/error:
+  /bulkQuotes/{ID}/error:
     $ref: 'paths/bulkQuotes_ID_error.yaml'
   /bulkTransfers:
     $ref: 'paths/bulkTransfers.yaml'
-  /bulkTransfers/ID:
+  /bulkTransfers/{ID}:
     $ref: 'paths/bulkTransfers_ID.yaml'
-  /bulkTransfers/ID/error:
+  /bulkTransfers/{ID}/error:
     $ref: 'paths/bulkTransfers_ID_error.yaml'

--- a/fspiop/v1_1/openapi3/openapi.yaml
+++ b/fspiop/v1_1/openapi3/openapi.yaml
@@ -48,63 +48,63 @@ paths:
       responses:
         200:
           description: Ok
-  /participants/Type/ID:
+  /participants/{Type}/{ID}:
     $ref: 'paths/participants_Type_ID.yaml'
-  /participants/Type/ID/error:
+  /participants/{Type}/{ID}/error:
     $ref: 'paths/participants_Type_ID_error.yaml'
-  /participants/Type/ID/SubId:
+  /participants/{Type}/{ID}/{SubId}:
     $ref: 'paths/participants_Type_ID_SubId.yaml'
-  /participants/Type/ID/SubId/error:
+  /participants/{Type}/{ID}/{SubId}/error:
     $ref: 'paths/participants_Type_ID_SubId_error.yaml'
   /participants:
     $ref: 'paths/participants.yaml'
-  /participants/ID:
+  /participants/{ID}:
     $ref: 'paths/participants_ID.yaml'
-  /participants/ID/error:
+  /participants/{ID}/error:
     $ref: 'paths/participants_ID_error.yaml'
-  /parties/Type/ID:
+  /parties/{Type}/{ID}:
     $ref: 'paths/parties_Type_ID.yaml'
-  /parties/Type/ID/error:
+  /parties/{Type}/{ID}/error:
     $ref: 'paths/parties_Type_ID_error.yaml'
-  /parties/Type/ID/SubId:
+  /parties/{Type}/{ID}/{SubId}:
     $ref: 'paths/parties_Type_ID_SubId.yaml'
-  /parties/Type/ID/SubId/error:
+  /parties/{Type}/{ID}/{SubId}/error:
     $ref: 'paths/parties_Type_ID_SubId_error.yaml'
   /transactionRequests:
     $ref: 'paths/transactionRequests.yaml'
-  /transactionRequests/ID:
+  /transactionRequests/{ID}:
     $ref: 'paths/transactionRequests_ID.yaml'
-  /transactionRequests/ID/error:
+  /transactionRequests/{ID}/error:
     $ref: 'paths/transactionRequests_ID_error.yaml'
   /quotes:
     $ref: 'paths/quotes.yaml'
-  /quotes/ID:
+  /quotes/{ID}:
     $ref: 'paths/quotes_ID.yaml'
-  /quotes/ID/error:
+  /quotes/{ID}/error:
     $ref: 'paths/quotes_ID_error.yaml'
-  /authorizations/ID:
+  /authorizations/{ID}:
     $ref: 'paths/authorizations_ID.yaml'
-  /authorizations/ID/error:
+  /authorizations/{ID}/error:
     $ref: 'paths/authorizations_ID_error.yaml'
   /transfers:
     $ref: 'paths/transfers.yaml'
-  /transfers/ID:
+  /transfers/{ID}:
     $ref: 'paths/transfers_ID.yaml'
-  /transfers/ID/error:
+  /transfers/{ID}/error:
     $ref: 'paths/transfers_ID_error.yaml'
-  /transactions/ID:
+  /transactions/{ID}:
     $ref: 'paths/transactions_ID.yaml'
-  /transactions/ID/error:
+  /transactions/{ID}/error:
     $ref: 'paths/transactions_ID_error.yaml'
   /bulkQuotes:
     $ref: 'paths/bulkQuotes.yaml'
-  /bulkQuotes/ID:
+  /bulkQuotes/{ID}:
     $ref: 'paths/bulkQuotes_ID.yaml'
-  /bulkQuotes/ID/error:
+  /bulkQuotes/{ID}/error:
     $ref: 'paths/bulkQuotes_ID_error.yaml'
   /bulkTransfers:
     $ref: 'paths/bulkTransfers.yaml'
-  /bulkTransfers/ID:
+  /bulkTransfers/{ID}:
     $ref: 'paths/bulkTransfers_ID.yaml'
-  /bulkTransfers/ID/error:
+  /bulkTransfers/{ID}/error:
     $ref: 'paths/bulkTransfers_ID_error.yaml'


### PR DESCRIPTION
`openapi-cli split` names path files something pretty keystroke heavy like 'paths/parties@{Type}@{ID}@{SubId}_error.yaml'

In my renaming of all the paths I accidently updated the path keys which need the curly's for parameter notation.

Shouldn't affect any of the dependants since nothing references the `openapi.yaml` files directly.