### PR TITLE
refactor(consent): use schema from Webauthn browser create api

### DIFF
--- a/docs/thirdparty-openapi3-snippets.yaml
+++ b/docs/thirdparty-openapi3-snippets.yaml
@@ -3134,109 +3134,48 @@ paths:
                                     base64 encoded
 
                                     https://w3c.github.io/webauthn/#ref-for-dom-credential-id
+                                  minLength: 59
+                                  maxLength: 118
+                                rawId:
+                                  type: string
+                                  description: >
+                                    raw credential id: identifier of pair of
+                                    keys, base64 encoded
+                                  minLength: 59
+                                  maxLength: 118
                                 response:
                                   type: object
                                   description: |
                                     AuthenticatorAttestationResponse
                                   properties:
-                                    clientData:
-                                      type: object
-                                      description: >
-                                        parsed
-                                        AuthenticatorAttestationResponse.clientDataJSON
-
-                                        client data used to create credential
-
-                                        https://webauthn.guide/#registration
-                                      properties:
-                                        challenge:
-                                          type: string
-                                          description: the challenge used to create credential
-                                        origin:
-                                          type: string
-                                          description: the origin used to create credential
-                                        type:
-                                          type: string
-                                          enum:
-                                            - webauthn.create
-                                          description: >
-                                            If another string is provided, it
-                                            indicates that the authenticator
-                                            performed an incorrect operation.
-
-                                            In such case OpenAPI framework will send
-                                            back the status 400 
-                                      required:
-                                        - challenge
-                                        - origin
-                                        - type
-                                      additionalProperties: false
-                                    attestation:
-                                      type: object
-                                      description: >
-                                        CBOR.Decoded
-                                        AuthenticatorAttestationResponse.attestationObject
-
-                                        https://webauthn.guide/#registration
-                                      properties:
-                                        authData:
-                                          type: string
-                                          description: >
-                                            base64 encoded byte array
-                                            Uint8Array(196) with publicKey and
-                                            metadata
-
-                                            parsing example can be found here:
-
-                                            https://webauthn.guide/#registration
-                                          minLength: 196
-                                          maxLength: 392
-                                        format:
-                                          type: string
-                                          description: >
-                                            attestation statement format
-
-                                            Authenticators can provide attestation
-                                            data in a number of ways; this indicates
-                                            how the server should parse and validate
-                                            the attestation data
-
-                                            https://webauthn.guide/#registration
-                                          enum:
-                                            - fido-u2f
-                                        statement:
-                                          type: object
-                                          description: >
-                                            The FIDO statement format when `format:
-                                            'fido-u2f'` only!
-
-                                            It can differ when other format types
-                                            are enabled!
-                                          properties:
-                                            sig:
-                                              type: string
-                                              description: |
-                                                signature
-                                                base64 encoded Uint8Array(70)
-                                              minLength: 70
-                                              maxLength: 140
-                                            x5c:
-                                              type: string
-                                              description: |
-                                                attestation certificate in X.509 format
-                                              minLength: 1
-                                              maxLength: 4096
-                                          required:
-                                            - sig
-                                            - x5c
-                                          additionalProperties: false
+                                    clientDataJSON:
+                                      type: string
+                                      description: |
+                                        JSON string with client data
+                                      minLength: 121
+                                      maxLength: 242
+                                    attestationObject:
+                                      type: string
+                                      description: |
+                                        CBOR.encoded attestation object
+                                      minLength: 306
+                                      maxLength: 712
                                   required:
-                                    - clientData
-                                    - attestation
+                                    - clientDataJSON
+                                    - attestationObject
                                   additionalProperties: false
+                                type:
+                                  type: string
+                                  description: >-
+                                    response type, we need only the type of
+                                    public-key
+                                  enum:
+                                    - public-key
                               required: &ref_58
                                 - id
+                                - rawId
                                 - response
+                                - type
                               additionalProperties: false
                           required: &ref_55
                             - credentialType

--- a/src/thirdparty/openapi.ts
+++ b/src/thirdparty/openapi.ts
@@ -8141,63 +8141,26 @@ export interface operations {
                  */
             id: string;
             /**
+                 * raw credential id: identifier of pair of keys, base64 encoded
+                 */
+            rawId: string;
+            /**
                  * AuthenticatorAttestationResponse
                  */
             response: {
               /**
-                   * parsed AuthenticatorAttestationResponse.clientDataJSON
-                   * client data used to create credential
-                   * https://webauthn.guide/#registration
+                   * JSON string with client data
                    */
-              clientData: {
-                /**
-                     * the challenge used to create credential
-                     */
-                challenge: string;
-                /**
-                     * the origin used to create credential
-                     */
-                origin: string;
-                /**
-                     * If another string is provided, it indicates that the authenticator performed an incorrect operation.
-                     * In such case OpenAPI framework will send back the status 400
-                     */
-                type: "webauthn.create";
-              };
+              clientDataJSON: string;
               /**
-                   * CBOR.Decoded AuthenticatorAttestationResponse.attestationObject
-                   * https://webauthn.guide/#registration
+                   * CBOR.encoded attestation object
                    */
-              attestation: {
-                /**
-                     * base64 encoded byte array Uint8Array(196) with publicKey and metadata
-                     * parsing example can be found here:
-                     * https://webauthn.guide/#registration
-                     */
-                authData?: string;
-                /**
-                     * attestation statement format
-                     * Authenticators can provide attestation data in a number of ways; this indicates how the server should parse and validate the attestation data
-                     * https://webauthn.guide/#registration
-                     */
-                format?: "fido-u2f";
-                /**
-                     * The FIDO statement format when `format: 'fido-u2f'` only!
-                     * It can differ when other format types are enabled!
-                     */
-                statement?: {
-                  /**
-                       * signature
-                       * base64 encoded Uint8Array(70)
-                       */
-                  sig: string;
-                  /**
-                       * attestation certificate in X.509 format
-                       */
-                  x5c: string;
-                };
-              };
+              attestationObject: string;
             };
+            /**
+                 * response type, we need only the type of public-key
+                 */
+            type: "public-key";
           };
         };
       }
@@ -9277,63 +9240,26 @@ export interface operations {
                  */
             id: string;
             /**
+                 * raw credential id: identifier of pair of keys, base64 encoded
+                 */
+            rawId: string;
+            /**
                  * AuthenticatorAttestationResponse
                  */
             response: {
               /**
-                   * parsed AuthenticatorAttestationResponse.clientDataJSON
-                   * client data used to create credential
-                   * https://webauthn.guide/#registration
+                   * JSON string with client data
                    */
-              clientData: {
-                /**
-                     * the challenge used to create credential
-                     */
-                challenge: string;
-                /**
-                     * the origin used to create credential
-                     */
-                origin: string;
-                /**
-                     * If another string is provided, it indicates that the authenticator performed an incorrect operation.
-                     * In such case OpenAPI framework will send back the status 400
-                     */
-                type: "webauthn.create";
-              };
+              clientDataJSON: string;
               /**
-                   * CBOR.Decoded AuthenticatorAttestationResponse.attestationObject
-                   * https://webauthn.guide/#registration
+                   * CBOR.encoded attestation object
                    */
-              attestation: {
-                /**
-                     * base64 encoded byte array Uint8Array(196) with publicKey and metadata
-                     * parsing example can be found here:
-                     * https://webauthn.guide/#registration
-                     */
-                authData?: string;
-                /**
-                     * attestation statement format
-                     * Authenticators can provide attestation data in a number of ways; this indicates how the server should parse and validate the attestation data
-                     * https://webauthn.guide/#registration
-                     */
-                format?: "fido-u2f";
-                /**
-                     * The FIDO statement format when `format: 'fido-u2f'` only!
-                     * It can differ when other format types are enabled!
-                     */
-                statement?: {
-                  /**
-                       * signature
-                       * base64 encoded Uint8Array(70)
-                       */
-                  sig: string;
-                  /**
-                       * attestation certificate in X.509 format
-                       */
-                  x5c: string;
-                };
-              };
+              attestationObject: string;
             };
+            /**
+                 * response type, we need only the type of public-key
+                 */
+            type: "public-key";
           };
         };
       }
@@ -9379,63 +9305,26 @@ export interface operations {
                  */
             id: string;
             /**
+                 * raw credential id: identifier of pair of keys, base64 encoded
+                 */
+            rawId: string;
+            /**
                  * AuthenticatorAttestationResponse
                  */
             response: {
               /**
-                   * parsed AuthenticatorAttestationResponse.clientDataJSON
-                   * client data used to create credential
-                   * https://webauthn.guide/#registration
+                   * JSON string with client data
                    */
-              clientData: {
-                /**
-                     * the challenge used to create credential
-                     */
-                challenge: string;
-                /**
-                     * the origin used to create credential
-                     */
-                origin: string;
-                /**
-                     * If another string is provided, it indicates that the authenticator performed an incorrect operation.
-                     * In such case OpenAPI framework will send back the status 400
-                     */
-                type: "webauthn.create";
-              };
+              clientDataJSON: string;
               /**
-                   * CBOR.Decoded AuthenticatorAttestationResponse.attestationObject
-                   * https://webauthn.guide/#registration
+                   * CBOR.encoded attestation object
                    */
-              attestation: {
-                /**
-                     * base64 encoded byte array Uint8Array(196) with publicKey and metadata
-                     * parsing example can be found here:
-                     * https://webauthn.guide/#registration
-                     */
-                authData?: string;
-                /**
-                     * attestation statement format
-                     * Authenticators can provide attestation data in a number of ways; this indicates how the server should parse and validate the attestation data
-                     * https://webauthn.guide/#registration
-                     */
-                format?: "fido-u2f";
-                /**
-                     * The FIDO statement format when `format: 'fido-u2f'` only!
-                     * It can differ when other format types are enabled!
-                     */
-                statement?: {
-                  /**
-                       * signature
-                       * base64 encoded Uint8Array(70)
-                       */
-                  sig: string;
-                  /**
-                       * attestation certificate in X.509 format
-                       */
-                  x5c: string;
-                };
-              };
+              attestationObject: string;
             };
+            /**
+                 * response type, we need only the type of public-key
+                 */
+            type: "public-key";
           };
         };
       };
@@ -26747,63 +26636,26 @@ export interface components {
        */
       id: string;
       /**
+       * raw credential id: identifier of pair of keys, base64 encoded
+       */
+      rawId: string;
+      /**
        * AuthenticatorAttestationResponse
        */
       response: {
         /**
-         * parsed AuthenticatorAttestationResponse.clientDataJSON
-         * client data used to create credential
-         * https://webauthn.guide/#registration
+         * JSON string with client data
          */
-        clientData: {
-          /**
-           * the challenge used to create credential
-           */
-          challenge: string;
-          /**
-           * the origin used to create credential
-           */
-          origin: string;
-          /**
-           * If another string is provided, it indicates that the authenticator performed an incorrect operation.
-           * In such case OpenAPI framework will send back the status 400
-           */
-          type: "webauthn.create";
-        };
+        clientDataJSON: string;
         /**
-         * CBOR.Decoded AuthenticatorAttestationResponse.attestationObject
-         * https://webauthn.guide/#registration
+         * CBOR.encoded attestation object
          */
-        attestation: {
-          /**
-           * base64 encoded byte array Uint8Array(196) with publicKey and metadata
-           * parsing example can be found here:
-           * https://webauthn.guide/#registration
-           */
-          authData?: string;
-          /**
-           * attestation statement format
-           * Authenticators can provide attestation data in a number of ways; this indicates how the server should parse and validate the attestation data
-           * https://webauthn.guide/#registration
-           */
-          format?: "fido-u2f";
-          /**
-           * The FIDO statement format when `format: 'fido-u2f'` only!
-           * It can differ when other format types are enabled!
-           */
-          statement?: {
-            /**
-             * signature
-             * base64 encoded Uint8Array(70)
-             */
-            sig: string;
-            /**
-             * attestation certificate in X.509 format
-             */
-            x5c: string;
-          };
-        };
+        attestationObject: string;
       };
+      /**
+       * response type, we need only the type of public-key
+       */
+      type: "public-key";
     };
     /**
      * A credential used to allow a user to prove their identity and access
@@ -26837,63 +26689,26 @@ export interface components {
          */
         id: string;
         /**
+         * raw credential id: identifier of pair of keys, base64 encoded
+         */
+        rawId: string;
+        /**
          * AuthenticatorAttestationResponse
          */
         response: {
           /**
-           * parsed AuthenticatorAttestationResponse.clientDataJSON
-           * client data used to create credential
-           * https://webauthn.guide/#registration
+           * JSON string with client data
            */
-          clientData: {
-            /**
-             * the challenge used to create credential
-             */
-            challenge: string;
-            /**
-             * the origin used to create credential
-             */
-            origin: string;
-            /**
-             * If another string is provided, it indicates that the authenticator performed an incorrect operation.
-             * In such case OpenAPI framework will send back the status 400
-             */
-            type: "webauthn.create";
-          };
+          clientDataJSON: string;
           /**
-           * CBOR.Decoded AuthenticatorAttestationResponse.attestationObject
-           * https://webauthn.guide/#registration
+           * CBOR.encoded attestation object
            */
-          attestation: {
-            /**
-             * base64 encoded byte array Uint8Array(196) with publicKey and metadata
-             * parsing example can be found here:
-             * https://webauthn.guide/#registration
-             */
-            authData?: string;
-            /**
-             * attestation statement format
-             * Authenticators can provide attestation data in a number of ways; this indicates how the server should parse and validate the attestation data
-             * https://webauthn.guide/#registration
-             */
-            format?: "fido-u2f";
-            /**
-             * The FIDO statement format when `format: 'fido-u2f'` only!
-             * It can differ when other format types are enabled!
-             */
-            statement?: {
-              /**
-               * signature
-               * base64 encoded Uint8Array(70)
-               */
-              sig: string;
-              /**
-               * attestation certificate in X.509 format
-               */
-              x5c: string;
-            };
-          };
+          attestationObject: string;
         };
+        /**
+         * response type, we need only the type of public-key
+         */
+        type: "public-key";
       };
     };
     /**
@@ -26941,63 +26756,26 @@ export interface components {
            */
           id: string;
           /**
+           * raw credential id: identifier of pair of keys, base64 encoded
+           */
+          rawId: string;
+          /**
            * AuthenticatorAttestationResponse
            */
           response: {
             /**
-             * parsed AuthenticatorAttestationResponse.clientDataJSON
-             * client data used to create credential
-             * https://webauthn.guide/#registration
+             * JSON string with client data
              */
-            clientData: {
-              /**
-               * the challenge used to create credential
-               */
-              challenge: string;
-              /**
-               * the origin used to create credential
-               */
-              origin: string;
-              /**
-               * If another string is provided, it indicates that the authenticator performed an incorrect operation.
-               * In such case OpenAPI framework will send back the status 400
-               */
-              type: "webauthn.create";
-            };
+            clientDataJSON: string;
             /**
-             * CBOR.Decoded AuthenticatorAttestationResponse.attestationObject
-             * https://webauthn.guide/#registration
+             * CBOR.encoded attestation object
              */
-            attestation: {
-              /**
-               * base64 encoded byte array Uint8Array(196) with publicKey and metadata
-               * parsing example can be found here:
-               * https://webauthn.guide/#registration
-               */
-              authData?: string;
-              /**
-               * attestation statement format
-               * Authenticators can provide attestation data in a number of ways; this indicates how the server should parse and validate the attestation data
-               * https://webauthn.guide/#registration
-               */
-              format?: "fido-u2f";
-              /**
-               * The FIDO statement format when `format: 'fido-u2f'` only!
-               * It can differ when other format types are enabled!
-               */
-              statement?: {
-                /**
-                 * signature
-                 * base64 encoded Uint8Array(70)
-                 */
-                sig: string;
-                /**
-                 * attestation certificate in X.509 format
-                 */
-                x5c: string;
-              };
-            };
+            attestationObject: string;
           };
+          /**
+           * response type, we need only the type of public-key
+           */
+          type: "public-key";
         };
       };
     };
@@ -27072,63 +26850,26 @@ export interface components {
            */
           id: string;
           /**
+           * raw credential id: identifier of pair of keys, base64 encoded
+           */
+          rawId: string;
+          /**
            * AuthenticatorAttestationResponse
            */
           response: {
             /**
-             * parsed AuthenticatorAttestationResponse.clientDataJSON
-             * client data used to create credential
-             * https://webauthn.guide/#registration
+             * JSON string with client data
              */
-            clientData: {
-              /**
-               * the challenge used to create credential
-               */
-              challenge: string;
-              /**
-               * the origin used to create credential
-               */
-              origin: string;
-              /**
-               * If another string is provided, it indicates that the authenticator performed an incorrect operation.
-               * In such case OpenAPI framework will send back the status 400
-               */
-              type: "webauthn.create";
-            };
+            clientDataJSON: string;
             /**
-             * CBOR.Decoded AuthenticatorAttestationResponse.attestationObject
-             * https://webauthn.guide/#registration
+             * CBOR.encoded attestation object
              */
-            attestation: {
-              /**
-               * base64 encoded byte array Uint8Array(196) with publicKey and metadata
-               * parsing example can be found here:
-               * https://webauthn.guide/#registration
-               */
-              authData?: string;
-              /**
-               * attestation statement format
-               * Authenticators can provide attestation data in a number of ways; this indicates how the server should parse and validate the attestation data
-               * https://webauthn.guide/#registration
-               */
-              format?: "fido-u2f";
-              /**
-               * The FIDO statement format when `format: 'fido-u2f'` only!
-               * It can differ when other format types are enabled!
-               */
-              statement?: {
-                /**
-                 * signature
-                 * base64 encoded Uint8Array(70)
-                 */
-                sig: string;
-                /**
-                 * attestation certificate in X.509 format
-                 */
-                x5c: string;
-              };
-            };
+            attestationObject: string;
           };
+          /**
+           * response type, we need only the type of public-key
+           */
+          type: "public-key";
         };
       };
     };
@@ -27164,63 +26905,26 @@ export interface components {
          */
         id: string;
         /**
+         * raw credential id: identifier of pair of keys, base64 encoded
+         */
+        rawId: string;
+        /**
          * AuthenticatorAttestationResponse
          */
         response: {
           /**
-           * parsed AuthenticatorAttestationResponse.clientDataJSON
-           * client data used to create credential
-           * https://webauthn.guide/#registration
+           * JSON string with client data
            */
-          clientData: {
-            /**
-             * the challenge used to create credential
-             */
-            challenge: string;
-            /**
-             * the origin used to create credential
-             */
-            origin: string;
-            /**
-             * If another string is provided, it indicates that the authenticator performed an incorrect operation.
-             * In such case OpenAPI framework will send back the status 400
-             */
-            type: "webauthn.create";
-          };
+          clientDataJSON: string;
           /**
-           * CBOR.Decoded AuthenticatorAttestationResponse.attestationObject
-           * https://webauthn.guide/#registration
+           * CBOR.encoded attestation object
            */
-          attestation: {
-            /**
-             * base64 encoded byte array Uint8Array(196) with publicKey and metadata
-             * parsing example can be found here:
-             * https://webauthn.guide/#registration
-             */
-            authData?: string;
-            /**
-             * attestation statement format
-             * Authenticators can provide attestation data in a number of ways; this indicates how the server should parse and validate the attestation data
-             * https://webauthn.guide/#registration
-             */
-            format?: "fido-u2f";
-            /**
-             * The FIDO statement format when `format: 'fido-u2f'` only!
-             * It can differ when other format types are enabled!
-             */
-            statement?: {
-              /**
-               * signature
-               * base64 encoded Uint8Array(70)
-               */
-              sig: string;
-              /**
-               * attestation certificate in X.509 format
-               */
-              x5c: string;
-            };
-          };
+          attestationObject: string;
         };
+        /**
+         * response type, we need only the type of public-key
+         */
+        type: "public-key";
       };
     };
     /**
@@ -27269,63 +26973,26 @@ export interface components {
            */
           id: string;
           /**
+           * raw credential id: identifier of pair of keys, base64 encoded
+           */
+          rawId: string;
+          /**
            * AuthenticatorAttestationResponse
            */
           response: {
             /**
-             * parsed AuthenticatorAttestationResponse.clientDataJSON
-             * client data used to create credential
-             * https://webauthn.guide/#registration
+             * JSON string with client data
              */
-            clientData: {
-              /**
-               * the challenge used to create credential
-               */
-              challenge: string;
-              /**
-               * the origin used to create credential
-               */
-              origin: string;
-              /**
-               * If another string is provided, it indicates that the authenticator performed an incorrect operation.
-               * In such case OpenAPI framework will send back the status 400
-               */
-              type: "webauthn.create";
-            };
+            clientDataJSON: string;
             /**
-             * CBOR.Decoded AuthenticatorAttestationResponse.attestationObject
-             * https://webauthn.guide/#registration
+             * CBOR.encoded attestation object
              */
-            attestation: {
-              /**
-               * base64 encoded byte array Uint8Array(196) with publicKey and metadata
-               * parsing example can be found here:
-               * https://webauthn.guide/#registration
-               */
-              authData?: string;
-              /**
-               * attestation statement format
-               * Authenticators can provide attestation data in a number of ways; this indicates how the server should parse and validate the attestation data
-               * https://webauthn.guide/#registration
-               */
-              format?: "fido-u2f";
-              /**
-               * The FIDO statement format when `format: 'fido-u2f'` only!
-               * It can differ when other format types are enabled!
-               */
-              statement?: {
-                /**
-                 * signature
-                 * base64 encoded Uint8Array(70)
-                 */
-                sig: string;
-                /**
-                 * attestation certificate in X.509 format
-                 */
-                x5c: string;
-              };
-            };
+            attestationObject: string;
           };
+          /**
+           * response type, we need only the type of public-key
+           */
+          type: "public-key";
         };
       };
     };

--- a/tests/dto/thirdparty.test.ts
+++ b/tests/dto/thirdparty.test.ts
@@ -103,21 +103,16 @@ describe('thirdparty', () => {
   const partyIdTypeEMAIL: Schemas.PartyIdType = 'EMAIL'
   const fidoPublicKeyCredential: Schemas.FIDOPublicKeyCredential = {
     id: 'some-credential-id',
+    rawId: 'some-raw-id',
     response: {
-      clientData: {
+      clientDataJSON: JSON.stringify({
         challenge: 'the-challenge',
         origin: 'pisp.mojaloop.io',
         type: 'webauthn.create'
-      },
-      attestation: {
-        authData: 'some-auth-data-with-PublicKey-and-some-metadata',
-        format: 'fido-u2f',
-        statement: {
-          sig: 'signature',
-          x5c: 'x.509 certificate'
-        }
-      }
-    }
+      }),
+      attestationObject: "some-attestation"
+    },
+    type: 'public-key'
   }
   const signedCredential: Schemas.SignedCredential = {
     credentialType: credentialTypeFIDO,
@@ -444,21 +439,16 @@ describe('thirdparty', () => {
   test('PublicKeyCredential', () => {
     const fidoPublicKeyCredential: Schemas.FIDOPublicKeyCredential = {
       id: 'some-credential-id',
+      rawId: 'some-raw-id',
       response: {
-        clientData: {
+        clientDataJSON: JSON.stringify({
           challenge: 'the-challenge',
           origin: 'pisp.mojaloop.io',
           type: 'webauthn.create'
-        },
-        attestation: {
-          authData: 'some-auth-data-with-PublicKey-and-some-metadata',
-          format: 'fido-u2f',
-          statement: {
-            sig: 'signature',
-            x5c: 'x.509 certificate'
-          }
-        }
-      }
+        }),
+        attestationObject: "some-attestation"
+      },
+      type: 'public-key'
     }
     expect(fidoPublicKeyCredential).toBeDefined()
   })

--- a/thirdparty/openapi3/components/schemas/FIDOPublicKeyCredential.yaml
+++ b/thirdparty/openapi3/components/schemas/FIDOPublicKeyCredential.yaml
@@ -12,92 +12,43 @@ properties:
     description: |
       credential id: identifier of pair of keys, base64 encoded
       https://w3c.github.io/webauthn/#ref-for-dom-credential-id
+    minLength: 59
+    maxLength: 118
+  rawId:
+    type: string
+    description: |
+      raw credential id: identifier of pair of keys, base64 encoded
+    minLength: 59
+    maxLength: 118
   response:
     type: object
     description: |
       AuthenticatorAttestationResponse
     properties:
-      clientData:
-        type: object
+      clientDataJSON:
+        type: string
         description: |
-          parsed AuthenticatorAttestationResponse.clientDataJSON
-          client data used to create credential
-          https://webauthn.guide/#registration
-        properties:
-          challenge:
-            type: string
-            description: the challenge used to create credential
-          origin:
-            type: string
-            description: the origin used to create credential
-          type:
-            type: string
-            enum:
-              - webauthn.create
-            description: |
-               If another string is provided, it indicates that the authenticator performed an incorrect operation.
-               In such case OpenAPI framework will send back the status 400 
-        required: 
-          - challenge
-          - origin
-          - type
-        additionalProperties: false
-      attestation: 
-        type: object
+          JSON string with client data
+        minLength: 121
+        maxLength: 242
+      attestationObject: 
+        type: string
         description: |
-          CBOR.Decoded AuthenticatorAttestationResponse.attestationObject
-          https://webauthn.guide/#registration
-        properties:
-          authData: 
-            type: string
-            description: |
-              base64 encoded byte array Uint8Array(196) with publicKey and metadata
-              parsing example can be found here:
-              https://webauthn.guide/#registration
-            minLength: 196
-            maxLength: 392
-          format:
-            type: string
-            description: |
-              attestation statement format
-              Authenticators can provide attestation data in a number of ways; this indicates how the server should parse and validate the attestation data
-              https://webauthn.guide/#registration
-            enum:
-              # we only accept FIDO flow
-              # list of allowed formats: https://www.iana.org/assignments/webauthn/webauthn.xhtml
-              # - packed
-              # - tpm
-              # - android-key
-              # - andorid-safetynet
-              - fido-u2f  
-          statement:
-            type: object
-            description: |
-              The FIDO statement format when `format: 'fido-u2f'` only!
-              It can differ when other format types are enabled!
-            properties:
-              sig:
-                type: string
-                description: |
-                  signature
-                  base64 encoded Uint8Array(70)
-                minLength: 70
-                maxLength: 140
-              x5c:
-                type: string
-                description: |
-                  attestation certificate in X.509 format
-                minLength: 1
-                maxLength: 4096 # TODO: check how big this string could be.... 
-            required:
-              - sig
-              - x5c
-            additionalProperties: false
+          CBOR.encoded attestation object
+        minLength: 306
+        maxLength: 712
     required:
-      - clientData
-      - attestation
+      - clientDataJSON
+      - attestationObject
     additionalProperties: false
+  type:
+    type: string
+    description: response type, we need only the type of public-key
+    enum: 
+      - 'public-key'
 required:
   - id
+  - rawId
   - response
+  - type
 additionalProperties: false


### PR DESCRIPTION
after the talk with @lewisdaly ,
we decided to go to the native scheme - the PublicKeyCredential format from the result of WebAuthn `navigator.credentials.create`