### PR TITLE
fix: use proper maxLength for credential.clientDataJSON

### DIFF
--- a/docs/thirdparty-openapi3-snippets.yaml
+++ b/docs/thirdparty-openapi3-snippets.yaml
@@ -3153,7 +3153,7 @@ paths:
                                       description: |
                                         JSON string with client data
                                       minLength: 121
-                                      maxLength: 242
+                                      maxLength: 512
                                     attestationObject:
                                       type: string
                                       description: |

--- a/docs/thirdparty-openapi3-snippets.yaml
+++ b/docs/thirdparty-openapi3-snippets.yaml
@@ -3159,7 +3159,7 @@ paths:
                                       description: |
                                         CBOR.encoded attestation object
                                       minLength: 306
-                                      maxLength: 712
+                                      maxLength: 2048
                                   required:
                                     - clientDataJSON
                                     - attestationObject

--- a/thirdparty/openapi3/components/schemas/FIDOPublicKeyCredential.yaml
+++ b/thirdparty/openapi3/components/schemas/FIDOPublicKeyCredential.yaml
@@ -36,7 +36,7 @@ properties:
         description: |
           CBOR.encoded attestation object
         minLength: 306
-        maxLength: 712
+        maxLength: 2048
     required:
       - clientDataJSON
       - attestationObject

--- a/thirdparty/openapi3/components/schemas/FIDOPublicKeyCredential.yaml
+++ b/thirdparty/openapi3/components/schemas/FIDOPublicKeyCredential.yaml
@@ -30,7 +30,7 @@ properties:
         description: |
           JSON string with client data
         minLength: 121
-        maxLength: 242
+        maxLength: 512
       attestationObject: 
         type: string
         description: |


### PR DESCRIPTION
thanks to Lewis example data I found out that the JSON string can be bigger than estimated