### PR TITLE
fix: remove path param from `POST /thirdpartyRequests/verifications` call

### DIFF
--- a/docs/thirdparty-openapi3-snippets.yaml
+++ b/docs/thirdparty-openapi3-snippets.yaml
@@ -2087,7 +2087,7 @@ paths:
                                     type: string
                                     description: |
                                       Authenticator data object.
-                                    minLength: 59
+                                    minLength: 49
                                     maxLength: 256
                                   clientDataJSON:
                                     type: string
@@ -7788,11 +7788,6 @@ paths:
           headers: *ref_35
   /thirdpartyRequests/verifications:
     parameters:
-      - name: ID
-        in: path
-        required: true
-        schema: *ref_36
-        description: The identifier value.
       - name: Content-Type
         in: header
         schema: *ref_37

--- a/src/thirdparty/openapi.ts
+++ b/src/thirdparty/openapi.ts
@@ -1188,12 +1188,6 @@ export interface paths {
   "/thirdpartyRequests/verifications": {
     post: operations["PostThirdpartyRequestsVerifications"];
     parameters: {
-      path: {
-        /**
-         * The identifier value.
-         */
-        ID: string;
-      };
       header: {
         /**
          * The `Content-Type` header indicates the specific version of the API used to send the payload body.

--- a/thirdparty/openapi3/paths/thirdpartyRequests_verifications.yaml
+++ b/thirdparty/openapi3/paths/thirdpartyRequests_verifications.yaml
@@ -1,6 +1,4 @@
 parameters:
-  #Path
-  - $ref: ../components/parameters/ID.yaml
   #Headers
   - $ref: ../components/parameters/Content-Type.yaml
   - $ref: ../components/parameters/Date.yaml


### PR DESCRIPTION
Oops... I feel your pain @kleyow 