### PR TITLE
fix(mojaloop/3003): SDK Interface /bulkTransaction definition restricts individualTransfers maxLimit

### DIFF
--- a/docs/sdk-scheme-adapter-outbound-v2_0_0-openapi3-snippets.yaml
+++ b/docs/sdk-scheme-adapter-outbound-v2_0_0-openapi3-snippets.yaml
@@ -1817,7 +1817,6 @@ paths:
                         accept party information.
                       type: array
                       minItems: 1
-                      maxItems: 1000
                       items:
                         allOf:
                           - type: object
@@ -1871,7 +1870,6 @@ paths:
                       description: List of individual transfers in a bulk transfer.
                       type: array
                       minItems: 1
-                      maxItems: 1000
                       items:
                         allOf:
                           - type: object

--- a/sdk-scheme-adapter/v2_0_0/components/schemas/bulkTransactionContinuationAcceptParty.yaml
+++ b/sdk-scheme-adapter/v2_0_0/components/schemas/bulkTransactionContinuationAcceptParty.yaml
@@ -17,7 +17,6 @@ properties:
       information.
     type: array
     minItems: 1
-    maxItems: 1000
     items:
       allOf:
         - $ref: ./bulkTransactionIndividualTransferAccept.yaml

--- a/sdk-scheme-adapter/v2_0_0/components/schemas/bulkTransactionContinuationAcceptQuote.yaml
+++ b/sdk-scheme-adapter/v2_0_0/components/schemas/bulkTransactionContinuationAcceptQuote.yaml
@@ -13,7 +13,6 @@ properties:
     description: List of individual transfers in a bulk transfer.
     type: array
     minItems: 1
-    maxItems: 1000
     items:
       allOf:
         - $ref: ./bulkTransactionIndividualTransferAccept.yaml

--- a/src/sdk-scheme-adapter/v2_0_0/outbound/json-schemas.json
+++ b/src/sdk-scheme-adapter/v2_0_0/outbound/json-schemas.json
@@ -9209,7 +9209,6 @@
         "description": "List of individual transfers in a bulk transfer with accept party information.",
         "type": "array",
         "minItems": 1,
-        "maxItems": 1000,
         "items": {
           "allOf": [
             {
@@ -9269,7 +9268,6 @@
         "description": "List of individual transfers in a bulk transfer.",
         "type": "array",
         "minItems": 1,
-        "maxItems": 1000,
         "items": {
           "allOf": [
             {
@@ -9434,7 +9432,6 @@
                     "description": "List of individual transfers in a bulk transfer with accept party information.",
                     "type": "array",
                     "minItems": 1,
-                    "maxItems": 1000,
                     "items": {
                       "allOf": [
                         {
@@ -9687,7 +9684,6 @@
                     "description": "List of individual transfers in a bulk transfer.",
                     "type": "array",
                     "minItems": 1,
-                    "maxItems": 1000,
                     "items": {
                       "allOf": [
                         {


### PR DESCRIPTION
fix(mojaloop/3003): SDK Interface /bulkTransaction method definition restricts number of individualTransfers to a max of 1000 - https://github.com/mojaloop/project/issues/3003