### PR TITLE
chore: update descriptions

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -5,6 +5,8 @@
     "moderate": true,
     "allowlist": [
         "GHSA-wf5p-g6vw-rhxx", // https://github.com/advisories/GHSA-wf5p-g6vw-rhxx
-        "GHSA-3h5v-q93c-6h6q"   // https://github.com/advisories/GHSA-3h5v-q93c-6h6q
+        "GHSA-3h5v-q93c-6h6q", // https://github.com/advisories/GHSA-3h5v-q93c-6h6q
+        "GHSA-cm22-4g7w-348p", // https://github.com/advisories/GHSA-cm22-4g7w-348p
+        "GHSA-m6fv-jmcg-4jfg"  // https://github.com/advisories/GHSA-m6fv-jmcg-4jfg
     ]
 }

--- a/docs/fspiop-rest-v2.0-ISO20022-openapi3-snippets.yaml
+++ b/docs/fspiop-rest-v2.0-ISO20022-openapi3-snippets.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.1.0
 info:
   version: v2.0-iso20022-draft
   title: Open API for FSP Interoperability (FSPIOP) - the ISO 20022 message version
@@ -1352,8 +1352,22 @@ components:
         account servicer.
       properties:
         IBAN:
+          description: >
+            IBAN
+
+            International Bank Account Number (IBAN) - identifier used
+            internationally by financial institutions to uniquely identify the
+            account of a customer. Further specifications of the format and
+            content of the IBAN can be found in the standard ISO 13616 "Banking
+            and related financial services - International Bank Account Number
+            (IBAN)" version 1997-10-01, or later revisions.
           $ref: "#/components/schemas/IBAN2007Identifier"
         Othr:
+          description: >
+            Other
+
+            Unique identification of an account, as assigned by the account
+            servicer, using an identification scheme.
           $ref: "#/components/schemas/GenericAccountIdentification1"
       oneOf:
         - required:
@@ -1369,8 +1383,16 @@ components:
         Sets of elements to identify a name of the identification scheme.
       properties:
         Cd:
+          description: >
+            Code
+
+            Name of the identification scheme, in a coded form as published in
+            an external list.
           $ref: "#/components/schemas/ExternalAccountIdentification1Code"
         Prtry:
+          description: |
+            Proprietary
+            Name of the identification scheme, in a free text form.
           $ref: "#/components/schemas/Max35Text"
       oneOf:
         - required:
@@ -1389,6 +1411,9 @@ components:
         ActiveCurrencyAndAmount:
           $ref: "#/components/schemas/ActiveCurrencyAndAmount_SimpleType"
         Ccy:
+          description: |
+            Currency
+            Identification of the currency in which the account is held.
           $ref: "#/components/schemas/ActiveCurrencyCode"
       required:
         - ActiveCurrencyAndAmount
@@ -1430,6 +1455,9 @@ components:
         ActiveOrHistoricCurrencyAndAmount:
           $ref: "#/components/schemas/ActiveOrHistoricCurrencyAndAmount_SimpleType"
         Ccy:
+          description: |
+            Currency
+            Identification of the currency in which the account is held.
           $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
       required:
         - ActiveOrHistoricCurrencyAndAmount
@@ -1455,6 +1483,7 @@ components:
     AddressType2Code:
       description: |
         AddressType2Code
+
         Specifies the type of address.
       enum:
         - ADDR
@@ -1472,8 +1501,14 @@ components:
         Choice of formats for the type of address.
       properties:
         Cd:
+          description: |
+            Code
+            Type of address expressed as a code.
           $ref: "#/components/schemas/AddressType2Code"
         Prtry:
+          description: |
+            Proprietary
+            Type of address expressed as a proprietary code.
           $ref: "#/components/schemas/GenericIdentification30"
       oneOf:
         - required:
@@ -1525,8 +1560,22 @@ components:
         branch of a financial institution.
       properties:
         FinInstnId:
+          description: >
+            FinancialInstitutionIdentification
+
+            Unique and unambiguous identification of a financial institution, as
+            assigned under an internationally recognised or proprietary
+            identification scheme.
           $ref: "#/components/schemas/FinancialInstitutionIdentification18"
         BrnchId:
+          description: >
+            BranchIdentification
+
+            Definition: Identifies a specific branch of a financial institution.
+
+            Usage: This component should be used in case the identification
+            information in the financial institution component does not provide
+            identification up to branch level.
           $ref: "#/components/schemas/BranchData3"
       required:
         - FinInstnId
@@ -1555,23 +1604,37 @@ components:
         branch of a financial institution.
       properties:
         FinInstnId:
+          description: >
+            FinancialInstitutionIdentification
+
+            Unique and unambiguous identification of a financial institution or
+            a branch of a financial institution.
           $ref: "#/components/schemas/FinancialInstitutionIdentification23"
         BrnchId:
+          description: |
+            BranchIdentification
+
+             Identifies a specific branch of a financial institution.
           $ref: "#/components/schemas/BranchData5"
       required:
         - FinInstnId
       example:
         FinInstnId:
-          BICFI: BUKBGB22
+          BICFI: J5BMVH7D
         BrnchId:
-          Id: 12345
-          Nm: Oxford Street Branch
+          Id: 123
+          Nm: Name
           PstlAdr:
-            Ctry: GB
-            AdrLine:
-              - 1 Oxford Street
-              - London
-              - UK
+            AdrTp: ADDR
+            Dept: Department
+            SubDept: Sub department
+            StrtNm: Street name
+            BldgNb: Building number
+            PstCd: Post code
+            TwnNm: Town name
+            CtrySubDvsn: Country subdivision
+            Ctry: Country
+            AdrLine: Address line
     BranchData3:
       title: BranchData3
       type: object
@@ -1580,12 +1643,32 @@ components:
         institution.
       properties:
         Id:
+          description: >
+            Identification
+
+            Unique and unambiguous identification of a branch of a financial
+            institution.
           $ref: "#/components/schemas/Max35Text"
         LEI:
+          description: >
+            Legal Entity Identifier
+
+            Legal entity identification for the branch of the financial
+            institution.
           $ref: "#/components/schemas/LEIIdentifier"
         Nm:
+          description: >
+            Name
+
+            Name by which an agent is known and which is usually used to
+            identify that agent.
           $ref: "#/components/schemas/Max140Text"
         PstlAdr:
+          description: >
+            Postal Address
+
+            Information that locates and identifies a specific address, as
+            defined by postal services.
           $ref: "#/components/schemas/PostalAddress24"
       example:
         Id: 123
@@ -1609,22 +1692,48 @@ components:
       type: object
       properties:
         Id:
+          description: >
+            identification
+
+            Unique and unambiguous identification of a branch of a financial
+            institution.
           $ref: "#/components/schemas/Max35Text"
         LEI:
+          description: >
+            LEI
+
+            Legal entity identification for the branch of the financial
+            institution.
           $ref: "#/components/schemas/LEIIdentifier"
         Nm:
+          description: >
+            Name
+
+            Name by which an agent is known and which is usually used to
+            identify that agent.
           $ref: "#/components/schemas/Max140Text"
         PstlAdr:
+          description: >
+            PostalAddress
+
+            Information that locates and identifies a specific address, as
+            defined by postal services.
           $ref: "#/components/schemas/PostalAddress27"
       example:
         Id: 123
-        Nm: Oxford Street Branch
+        LEI: 123
+        Nm: Name
         PstlAdr:
-          Ctry: GB
-          AdrLine:
-            - 1 Oxford Street
-            - London
-            - UK
+          AdrTp: ADDR
+          Dept: Department
+          SubDept: Sub department
+          StrtNm: Street name
+          BldgNb: Building number
+          PstCd: Post code
+          TwnNm: Town name
+          CtrySubDvsn: Country subdivision
+          Ctry: Country
+          AdrLine: Address line
     CashAccount40:
       title: CashAccount40
       type: object
@@ -1632,14 +1741,48 @@ components:
         Provides the details to identify an account.
       properties:
         Id:
+          description: >
+            Identification
+
+            Unique and unambiguous identification for the account between the
+            account owner and the account servicer.
           $ref: "#/components/schemas/AccountIdentification4Choice"
         Tp:
+          description: |
+            Type
+            Specifies the nature, or use of the account.
           $ref: "#/components/schemas/CashAccountType2Choice"
         Ccy:
+          description: >
+            Currency
+
+            Definition: Identification of the currency in which the account is
+            held.
+
+            Usage: Currency should only be used in case one and the same account
+            number covers several currencies and the initiating party needs to
+            identify which currency needs to be used for settlement on the
+            account.
           $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
         Nm:
+          description: >
+            Name
+
+            Definition: Name of the account, as assigned by the account
+            servicing institution, in agreement with the account owner in order
+            to provide an additional means of identification of the account.
+
+            Usage: The account name is different from the account owner name.
+            The account name is used in certain user communities to provide a
+            means of identifying the account, in addition to the account owner's
+            identity and the account number.
           $ref: "#/components/schemas/Max70Text"
         Prxy:
+          description: >
+            Proxy
+
+            Specifies an alternate assumed name for the identification of the
+            account.
           $ref: "#/components/schemas/ProxyAccountIdentification1"
       example:
         Id:
@@ -1657,8 +1800,14 @@ components:
       type: object
       properties:
         Cd:
+          description: |
+            Code
+            Account type, in a coded form.
           $ref: "#/components/schemas/ExternalCashAccountType1Code"
         Prtry:
+          description: |
+            Proprietary
+            Nature or use of the account in a proprietary form.
           $ref: "#/components/schemas/Max35Text"
       oneOf:
         - required:
@@ -1675,8 +1824,16 @@ components:
       type: object
       properties:
         Cd:
+          description: >
+            Code
+
+            Category purpose, as published in an external category purpose code
+            list.
           $ref: "#/components/schemas/ExternalCategoryPurpose1Code"
         Prtry:
+          description: |
+            Proprietary
+            Category purpose, in a proprietary form.
           $ref: "#/components/schemas/Max35Text"
       oneOf:
         - required:
@@ -1714,12 +1871,20 @@ components:
       example: DEBT
     ChargeType3Choice:
       title: ChargeType3Choice
-      description: ChargeType3Choice Specifies the type of charge.
+      description: |
+        ChargeType3Choice
+        Specifies the type of charge.
       type: object
       properties:
         Cd:
+          description: |
+            Code
+            Charge type, in a coded form.
           $ref: "#/components/schemas/ExternalChargeType1Code"
         Prtry:
+          description: |
+            Proprietary
+            Type of charge in a proprietary form, as defined by the issuer.
           $ref: "#/components/schemas/GenericIdentification3"
       oneOf:
         - required:
@@ -1732,13 +1897,28 @@ components:
       title: Charges16
       description: |
         NOTE: Unsure on description.
+
+        Seemingly a generic schema for charges, with an amount, agent, and type.
       type: object
       properties:
         Amt:
+          description: |
+            Amount
+
+             Transaction charges to be paid by the charge bearer.
           $ref: "#/components/schemas/ActiveOrHistoricCurrencyAndAmount"
         Agt:
+          description: >
+            Agent
+
+            Agent that takes the transaction charges or to which the transaction
+            charges are due.
           $ref: "#/components/schemas/BranchAndFinancialInstitutionIdentification8"
         Tp:
+          description: |
+            Type
+
+             Defines the type of charges.
           $ref: "#/components/schemas/ChargeType3Choice"
       required:
         - Amt
@@ -1784,8 +1964,16 @@ components:
       type: object
       properties:
         Cd:
+          description: |
+            Code
+            Identification of a member of a clearing system
           $ref: "#/components/schemas/ExternalClearingSystemIdentification1Code"
         Prtry:
+          description: >
+            Proprietary
+
+            Identification code for a clearing system, that has not yet been
+            identified in the list of clearing systems.
           $ref: "#/components/schemas/Max35Text"
       oneOf:
         - required:
@@ -1802,8 +1990,16 @@ components:
       type: object
       properties:
         ClrSysId:
+          description: >
+            ClearingSystemIdentification.
+
+            Specification of a pre-agreed offering between clearing agents or
+            the channel through which the payment instruction is processed.
           $ref: "#/components/schemas/ClearingSystemIdentification2Choice"
         MmbId:
+          description: |
+            MemberIdentification.
+            Identification of a member of a clearing system.
           $ref: "#/components/schemas/Max35Text"
       required:
         - MmbId
@@ -1818,30 +2014,79 @@ components:
       type: object
       properties:
         NmPrfx:
+          description: |
+            NamePrefix
+            Specifies the terms used to formally address a person.
           $ref: "#/components/schemas/NamePrefix2Code"
         Nm:
+          description: >
+            Name
+
+            Name by which a party is known and which is usually used to identify
+            that party.
           $ref: "#/components/schemas/Max140Text"
         PhneNb:
+          description: >
+            PhoneNumber
+
+            Collection of information that identifies a phone number, as defined
+            by telecom services.
           $ref: "#/components/schemas/PhoneNumber"
         MobNb:
+          description: >
+            MobilePhoneNumber
+
+            Collection of information that identifies a mobile phone number, as
+            defined by telecom services.
           $ref: "#/components/schemas/PhoneNumber"
         FaxNb:
+          description: >
+            FaxNumber
+
+            Collection of information that identifies a fax number, as defined
+            by telecom services.
           $ref: "#/components/schemas/PhoneNumber"
         URLAdr:
+          description: >
+            URLAddress
+
+            Address for the Universal Resource Locator (URL), for example an
+            address used over the www (HTTP) service.
           $ref: "#/components/schemas/Max2048Text"
         EmailAdr:
+          description: |
+            EmailAddress
+            Address for electronic mail (e-mail).
           $ref: "#/components/schemas/Max256Text"
         EmailPurp:
+          description: |
+            EmailPurpose
+            Purpose for which an email address may be used.
           $ref: "#/components/schemas/Max35Text"
         JobTitl:
+          description: |
+            JobTitle
+            Title of the function.
           $ref: "#/components/schemas/Max35Text"
         Rspnsblty:
+          description: |
+            Responsibility
+            Role of a person in an organisation.
           $ref: "#/components/schemas/Max35Text"
         Dept:
+          description: |
+            Department
+            Identification of a division of a large organisation or building.
           $ref: "#/components/schemas/Max70Text"
         Othr:
+          description: |
+            OtherContact
+            Contact details in another form.
           $ref: "#/components/schemas/OtherContact1"
         PrefrdMtd:
+          description: |
+            PreferredContactMethod
+            Preferred method used to reach the contact.
           $ref: "#/components/schemas/PreferredContactMethod2Code"
       example:
         NmPrfx: Mr
@@ -1858,28 +2103,72 @@ components:
       type: object
       properties:
         NmPrfx:
+          description: |
+            NamePrefix
+            Name prefix to be used before the name of the person.
           $ref: "#/components/schemas/NamePrefix2Code"
         Nm:
+          description: >
+            Name
+
+            Name by which a party is known and which is usually used to identify
+            that party.
           $ref: "#/components/schemas/Max140Text"
         PhneNb:
+          description: >
+            PhoneNumber
+
+            Collection of information that identifies a phone number, as defined
+            by telecom services.
           $ref: "#/components/schemas/PhoneNumber"
         MobNb:
+          description: >
+            MobilePhoneNumber
+
+            Collection of information that identifies a mobile phone number, as
+            defined by telecom services.
           $ref: "#/components/schemas/PhoneNumber"
         FaxNb:
+          description: >
+            FaxNumber
+
+            Collection of information that identifies a fax number, as defined
+            by telecom services.
           $ref: "#/components/schemas/PhoneNumber"
         EmailAdr:
+          description: |
+            EmailAddress
+            Address for electronic mail (e-mail).
           $ref: "#/components/schemas/Max2048Text"
         EmailPurp:
+          description: |
+            EmailPurpose
+            Purpose for which an email address may be used.
           $ref: "#/components/schemas/Max35Text"
         JobTitl:
+          description: |
+            JobTitle
+            Title of the function.
           $ref: "#/components/schemas/Max35Text"
         Rspnsblty:
+          description: |
+            Responsibility
+            Role of a person in an organisation.
           $ref: "#/components/schemas/Max35Text"
         Dept:
+          description: |
+            Department
+            Identification of a division of a large organisation or building.
           $ref: "#/components/schemas/Max70Text"
         Othr:
+          description: |
+            Other
+            : Contact details in another form.
           $ref: "#/components/schemas/OtherContact1"
         PrefrdMtd:
+          description: |
+            PreferredMethod
+            Preferred method used to reach the contact.
           $ref: "#/components/schemas/PreferredContactMethod1Code"
       example:
         NmPrfx: Mr
@@ -1893,6 +2182,10 @@ components:
       type: string
       pattern: ^[A-Z]{2,2}$
       example: US
+      description: >
+        Code to identify a country, a dependency, or another area of particular
+        geopolitical interest, on the basis of country names obtained from the
+        United Nations (ISO 3166, Alpha-2 code).
     CreditTransferTransaction67:
       title: CreditTransferTransaction67
       description: >
@@ -1901,40 +2194,115 @@ components:
       type: object
       properties:
         PmtId:
+          description: |
+            PaymentIdentification
+            Set of elements used to reference a payment instruction.
           $ref: "#/components/schemas/PaymentIdentification13"
         PmtTpInf:
+          description: |
+            PaymentTypeInformation
+
+             Set of elements used to further specify the type of transaction.
           $ref: "#/components/schemas/PaymentTypeInformation28"
         IntrBkSttlmAmt:
+          description: >
+            InterbankSettlementAmount
+
+            Amount of money moved between the instructing agent and the
+            instructed agent.
           $ref: "#/components/schemas/ActiveCurrencyAndAmount"
         InstdAmt:
+          description: >
+            InstructedAmount
+
+            Amount of money to be moved between the debtor and creditor, before
+            deduction of charges, expressed in the currency as ordered by the
+            initiating party.
           $ref: "#/components/schemas/ActiveOrHistoricCurrencyAndAmount"
         XchgRate:
+          description: >
+            ExchangeRate
+
+            Factor used to convert an amount from one currency into another.
+            This reflects the price at which one currency was bought with
+            another currency.
           $ref: "#/components/schemas/BaseOneRate"
         ChrgBr:
+          description: >
+            ChargeBearer
+
+            Specifies which party/parties will bear the charges associated with
+            the processing of the payment transaction.
           $ref: "#/components/schemas/ChargeBearerType1Code"
         ChrgsInf:
+          description: |
+            ChargesInformation
+
+             Provides information on the charges to be paid by the charge bearer(s) related to the
+            payment transaction
           $ref: "#/components/schemas/Charges16"
         Dbtr:
+          description: |
+            Debtor
+            Party that owes an amount of money to the (ultimate) creditor.
           $ref: "#/components/schemas/PartyIdentification272"
         DbtrAcct:
+          description: >
+            DebtorAccount
+
+            Unambiguous identification of the account of the debtor to which a
+            debit entry will be made as a result of the transaction.
           $ref: "#/components/schemas/CashAccount40"
         DbtrAgt:
+          description: |
+            DebtorAgent
+            Financial institution servicing an account for the debtor.
           $ref: "#/components/schemas/BranchAndFinancialInstitutionIdentification8"
         CdtrAgt:
+          description: |
+            CreditorAgent
+            Financial institution servicing an account for the creditor.
           $ref: "#/components/schemas/BranchAndFinancialInstitutionIdentification8"
         Cdtr:
+          description: |
+            Creditor
+            Party to which an amount of money is due.
           $ref: "#/components/schemas/PartyIdentification272"
         CdtrAcct:
+          description: >
+            CreditorAccount
+
+            Unambiguous identification of the account of the creditor to which a
+            credit entry will be posted as a result of the payment transaction.
           $ref: "#/components/schemas/CashAccount40"
         InstrForCdtrAgt:
+          description: >
+            InstructionForCreditorAgent
+
+            Set of elements used to provide information on the remittance
+            advice.
           $ref: "#/components/schemas/InstructionForCreditorAgent3"
         InstrForNxtAgt:
+          description: >
+            InstructionForNextAgent
+
+            Set of elements used to provide information on the remittance
+            advice.
           $ref: "#/components/schemas/InstructionForNextAgent1"
         Purp:
+          description: |
+            Purpose
+            Underlying reason for the payment transaction.
           $ref: "#/components/schemas/Purpose2Choice"
         RgltryRptg:
+          description: |
+            RegulatoryReporting
+            Information needed due to regulatory and statutory requirements.
           $ref: "#/components/schemas/RegulatoryReporting3"
         Tax:
+          description: |
+            Tax
+            Provides details on the tax.
           $ref: "#/components/schemas/TaxData1"
         VrfctnOfTerms:
           $ref: "#/components/schemas/CryptographicLockChoice"
@@ -2026,28 +2394,71 @@ components:
       type: object
       properties:
         PmtId:
+          description: |
+            PaymentIdentification
+            Set of elements used to reference a payment instruction.
           $ref: "#/components/schemas/PaymentIdentification13"
         PmtTpInf:
+          description: |
+            PaymentTypeInformation
+
+             Set of elements used to further specify the type of transaction.
           $ref: "#/components/schemas/PaymentTypeInformation28"
         IntrBkSttlmAmt:
+          description: >
+            InterbankSettlementAmount
+
+            Amount of money moved between the instructing agent and the
+            instructed agent.
           $ref: "#/components/schemas/ActiveCurrencyAndAmount"
         Dbtr:
+          description: |
+            Debtor
+            Party that owes an amount of money to the (ultimate) creditor.
           $ref: "#/components/schemas/BranchAndFinancialInstitutionIdentification8"
         DbtrAcct:
+          description: |
+            DebtorAccount
+            Account used to process a payment.
           $ref: "#/components/schemas/CashAccount40"
         DbtrAgt:
+          description: |
+            DebtorAgent
+            Financial institution servicing an account for the debtor.
           $ref: "#/components/schemas/BranchAndFinancialInstitutionIdentification8"
         CdtrAgt:
+          description: |
+            CreditorAgent
+            Financial institution servicing an account for the creditor.
           $ref: "#/components/schemas/BranchAndFinancialInstitutionIdentification8"
         Cdtr:
+          description: |
+            Creditor
+            Party to which an amount of money is due.
           $ref: "#/components/schemas/BranchAndFinancialInstitutionIdentification8"
         CdtrAcct:
+          description: |
+            CreditorAccount
+            Account to which a credit entry is made.
           $ref: "#/components/schemas/CashAccount40"
         InstrForCdtrAgt:
+          description: >
+            InstructionForCreditorAgent
+
+            Set of elements used to provide information on the remittance
+            advice.
           $ref: "#/components/schemas/InstructionForCreditorAgent3"
         Purp:
+          description: |
+            Purpose
+            Underlying reason for the payment transaction.
           $ref: "#/components/schemas/Purpose2Choice"
         VrfctnOfTerms:
+          description: >
+            VerificationOfTerms
+
+            Set of elements used to provide information on the underlying terms
+            of the transaction.
           $ref: "#/components/schemas/CryptographicLockChoice"
       required:
         - PmtId
@@ -2112,12 +2523,24 @@ components:
       type: object
       properties:
         BirthDt:
+          description: |
+            BirthDate
+            Date on which a person is born.
           $ref: "#/components/schemas/ISODate"
         PrvcOfBirth:
+          description: |
+            ProvinceOfBirth
+            Province where a person was born.
           $ref: "#/components/schemas/Max35Text"
         CityOfBirth:
+          description: |
+            CityOfBirth
+            City where a person was born.
           $ref: "#/components/schemas/Max35Text"
         CtryOfBirth:
+          description: |
+            CountryOfBirth
+            Country where a person was born.
           $ref: "#/components/schemas/CountryCode"
       required:
         - BirthDt
@@ -2135,15 +2558,21 @@ components:
       type: object
       properties:
         FrDt:
+          description: |
+            FromDate
+            Start date of the range.
           $ref: "#/components/schemas/ISODate"
         ToDt:
+          description: |
+            ToDate
+            End date of the range.
           $ref: "#/components/schemas/ISODate"
       required:
         - FrDt
         - ToDt
       example:
-        FrDt: "2020-01-01"
-        ToDt: "2020-12-31"
+        FrDt: "2022-01-01T00:00:00.000Z"
+        ToDt: "2022-12-31T23:59:59.999Z"
     ErrorCode:
       title: ErrorCode
       type: string
@@ -2205,63 +2634,71 @@ components:
       type: object
       properties:
         GrpHdr:
+          description: |
+            GroupHeader.
           $ref: "#/components/schemas/GroupHeader129"
         CdtTrfTxInf:
+          description: |
+            CreditTransferTransactionInformation.
           $ref: "#/components/schemas/CreditTransferTransaction67"
       required:
         - GrpHdr
         - CdtTrfTxInf
       example:
         GrpHdr:
-          MsgId: 123456789
+          MsgId: 12345
           CreDtTm: "2020-01-01T00:00:00Z"
+          PmtInstrXpryDtTm: "2020-01-01T00:00:00Z"
           NbOfTxs: 1
-          CtrlSum: 100
-          InitgPty:
-            Nm: Initiating Party Name
-            Id:
-              OrgId:
-                Othr:
-                  - Id: 123456789
-                    SchmeNm:
-                      Cd: 91
-          FwdgAgt:
-            FinInstnId:
-              BICFI: BBBBBBBB
+          SttlmInf:
+            SttlmMtd: INDA
+            SttlmAcct:
+              Id:
+                IBAN: 123
+            SttlmAcctOwnr:
+              Nm: John Doe
+            SttlmAcctSvcr:
+              BICFI: 123
+          CdtTrfTxInf:
+            PmtId:
+              InstrId: 123
+              EndToEndId: 123
+            PmtTpInf:
+              InstrPrty: NORM
+            InstdAmt:
+              Amt: 123
+              Ccy: EUR
+            ChrgBr: SLEV
+            CdtrAgt:
+              FinInstnId:
+                BICFI: 123
+            Cdtr:
+              Nm: John Doe
+            CdtrAcct:
+              Id:
+                IBAN: 123
+            RmtInf:
+              Ustrd: Test
         CdtTrfTxInf:
           PmtId:
-            InstrId: 123456789
-            EndToEndId: 123456789
+            InstrId: 123
+            EndToEndId: 123
           PmtTpInf:
             InstrPrty: NORM
-            CtgyPurp:
-              Cd: SUPP
-          InstrForCdtrAgt:
-            FinInstnId:
-              BICFI: AAAAAAAA
+          InstdAmt:
+            Amt: 123
+            Ccy: EUR
+          ChrgBr: SLEV
           CdtrAgt:
             FinInstnId:
-              BICFI: AAAAAAAA
+              BICFI: 123
           Cdtr:
-            Nm: Creditor Name
-            PstlAdr:
-              AdrLine:
-                - Creditor Address Line 1
-                - Creditor Address Line 2
-                - Creditor Address Line 3
-                - Creditor Address Line 4
-                - Creditor Address Line 5
-            Id:
-              OrgId:
-                Othr:
-                  - Id: 123456789
-                    SchmeNm:
-                      Cd: 91
+            Nm: John Doe
           CdtrAcct:
             Id:
-              IBAN: DE87123456781234567890
+              IBAN: 123
           RmtInf:
-            Ustrd: Remittance Information
+            Ustrd: Test
     Extension:
       title: Extension
       type: object
@@ -2413,8 +2850,16 @@ components:
       type: object
       properties:
         Cd:
+          description: >
+            Code
+
+            Name of the identification scheme, in a coded form as published in
+            an external list.
           $ref: "#/components/schemas/ExternalFinancialInstitutionIdentification1Code"
         Prtry:
+          description: |
+            Proprietary
+            Name of the identification scheme, in a free text form.
           $ref: "#/components/schemas/Max35Text"
       oneOf:
         - required:
@@ -2428,56 +2873,145 @@ components:
       type: object
       properties:
         BICFI:
+          description: >
+            BICFI
+
+            Code allocated to a financial institution by the ISO 9362
+            Registration Authority as described in ISO 9362 "Banking - Banking
+            telecommunication messages - Business identifier code (BIC)"
           $ref: "#/components/schemas/BICFIDec2014Identifier"
         ClrSysMmbId:
+          description: |
+            ClearingSystemMemberIdentification
+            Information used to identify a member within a clearing system
           $ref: "#/components/schemas/ClearingSystemMemberIdentification2"
         LEI:
+          description: |
+            LEI
+            Legal entity identifier of the financial institution.
           $ref: "#/components/schemas/LEIIdentifier"
         Nm:
+          description: >
+            Name
+
+            Name by which an agent is known and which is usually used to
+            identify that agent
           $ref: "#/components/schemas/Max140Text"
         PstlAdr:
+          description: >
+            PostalAddress
+
+            Information that locates and identifies a specific address, as
+            defined by postal services.
           $ref: "#/components/schemas/PostalAddress24"
         Othr:
+          description: >
+            Other
+
+            Unique identification of an agent, as assigned by an institution,
+            using an identification scheme.
           $ref: "#/components/schemas/GenericFinancialIdentification1"
       example:
-        BICFI: BUKBGB22
-        Nm: Barclays Bank Plc
+        BICFI: J5BMVH7D
+        ClrSysMmbId:
+          ClrSysId: 1234
+          MmbId: 123
+        LEI: 123
+        Nm: Name
         PstlAdr:
-          Ctry: GB
-          AdrLine:
-            - 1 Churchill Place
-            - London
-            - UK
+          AdrTp: ADDR
+          Dept: Department
+          SubDept: Sub department
+          StrtNm: Street name
+          BldgNb: Building number
+          PstCd: Post code
+          TwnNm: Town name
+          CtrySubDvsn: Country subdivision
+          Ctry: Country
+          AdrLine: Address line
+        Othr:
+          Id: 123
+          SchmeNm:
+            Cd: 123
+            Prtry: 123
+          Issr: 123
     FinancialInstitutionIdentification23:
       title: FinancialInstitutionIdentification23
       type: object
       properties:
         BICFI:
+          description: >
+            BICFI
+
+            Code allocated to a financial institution by the ISO 9362
+            Registration Authority as described in ISO 9362 "Banking - Banking
+            telecommunication messages - Business identifier code (BIC)"
           $ref: "#/components/schemas/BICFIDec2014Identifier"
         ClrSysMmbId:
+          description: |
+            ClearingSystemMemberIdentification
+            Information used to identify a member within a clearing system
           $ref: "#/components/schemas/ClearingSystemMemberIdentification2"
         LEI:
+          description: |
+            LEI
+            Legal entity identifier of the financial institution.
           $ref: "#/components/schemas/LEIIdentifier"
         Nm:
+          description: >
+            Name
+
+            Name by which an agent is known and which is usually used to
+            identify that agent
           $ref: "#/components/schemas/Max140Text"
         PstlAdr:
+          description: >
+            PostalAddress
+
+            Information that locates and identifies a specific address, as
+            defined by postal services.
           $ref: "#/components/schemas/PostalAddress27"
         Othr:
+          description: >
+            Other
+
+            Unique identification of an agent, as assigned by an institution,
+            using an identification scheme.
           $ref: "#/components/schemas/GenericFinancialIdentification1"
       example:
-        BICFI: BUKBGB22
-        Nm: Barclays Bank Plc
+        BICFI: J5BMVH7D
+        ClrSysMmbId:
+          ClrSysId:
+            Cd: CHQB
+          MmbId: 123456789
+        LEI: 123
+        Nm: Name
         PstlAdr:
-          Ctry: GB
-          AdrLine:
-            - 1 Churchill Place
-            - London
-            - UK
+          AdrTp: ADDR
+          Dept: Department
+          SubDept: Sub department
+          StrtNm: Street name
+          BldgNb: Building number
+          PstCd: Post code
+          TwnNm: Town name
+          CtrySubDvsn: Country subdivision
+          Ctry: Country
+          AdrLine: Address line
+        Othr:
+          Id: 123
+          SchmeNm:
+            Cd: CHQB
+          Issr: 123
     FxRequest_FICreditTransferProposal:
       title: FxRequest_FICreditTransferProposal
       type: object
       properties:
         GrpHdr:
+          description: >
+            GroupHeader
+
+            Set of characteristics shared by all individual transactions
+            included in the message.
           $ref: "#/components/schemas/GroupHeader113"
       required:
         - GrpHdr
@@ -2562,8 +3096,18 @@ components:
       type: object
       properties:
         GrpHdr:
+          description: >
+            GroupHeader
+
+            Set of characteristics shared by all individual transactions
+            included in the message.
           $ref: "#/components/schemas/GroupHeader113"
         CdtTrfTxInf:
+          description: >
+            CreditTransferTransactionInformation
+
+            Set of elements providing information specific to the individual
+            credit transfer(s).
           $ref: "#/components/schemas/CreditTransferTransaction68"
       required:
         - GrpHdr
@@ -2644,8 +3188,18 @@ components:
       type: object
       properties:
         GrpHdr:
+          description: >
+            GroupHeader.
+
+            Set of characteristics shared by all individual transactions
+            included in the message.
           $ref: "#/components/schemas/GroupHeader129"
         CdtTrfTxInf:
+          description: >
+            CreditTransferTransactionInformation.
+
+            Set of elements providing information specific to the individual
+            credit transfer(s).
           $ref: "#/components/schemas/CreditTransferTransaction68"
       required:
         - GrpHdr
@@ -2702,10 +3256,19 @@ components:
       type: object
       properties:
         Id:
+          description: |
+            Identification
+            Identification assigned by an institution.
           $ref: "#/components/schemas/Max34Text"
         SchmeNm:
+          description: |
+            SchemeName
+            Name of the identification scheme.
           $ref: "#/components/schemas/AccountSchemeName1Choice"
         Issr:
+          description: |
+            Issuer
+            Entity that assigns the identification.
           $ref: "#/components/schemas/Max35Text"
       required:
         - Id
@@ -2719,10 +3282,19 @@ components:
       type: object
       properties:
         Id:
+          description: |
+            Identification
+            Unique and unambiguous identification of a person.
           $ref: "#/components/schemas/Max35Text"
         SchmeNm:
+          description: |
+            SchemeName
+            Name of the identification scheme.
           $ref: "#/components/schemas/FinancialIdentificationSchemeName1Choice"
         Issr:
+          description: |
+            Issuer
+            Entity that assigns the identification.
           $ref: "#/components/schemas/Max35Text"
       required:
         - Id
@@ -2736,8 +3308,16 @@ components:
       type: object
       properties:
         Id:
+          description: >
+            Identification
+
+            Name or number assigned by an entity to enable recognition of that
+            entity, for example, account identifier.
           $ref: "#/components/schemas/Max35Text"
         Issr:
+          description: |
+            Issuer
+            Entity that assigns the identification.
           $ref: "#/components/schemas/Max35Text"
       required:
         - Id
@@ -2749,10 +3329,21 @@ components:
       type: object
       properties:
         Id:
+          description: >
+            Identification
+
+            Proprietary information, often a code, issued by the data source
+            scheme issuer
           $ref: "#/components/schemas/Exact4AlphaNumericText"
         Issr:
+          description: |
+            Issuer
+            Entity that assigns the identification.
           $ref: "#/components/schemas/Max35Text"
         SchmeNm:
+          description: |
+            SchemeName
+            Short textual description of the scheme.
           $ref: "#/components/schemas/Max35Text"
       required:
         - Id
@@ -2766,10 +3357,19 @@ components:
       type: object
       properties:
         Id:
+          description: |
+            Identification
+            Identification assigned by an institution.
           $ref: "#/components/schemas/Max35Text"
         SchmeNm:
+          description: |
+            SchemeName
+            Name of the identification scheme.
           $ref: "#/components/schemas/OrganisationIdentificationSchemeName1Choice"
         Issr:
+          description: |
+            Issuer
+            Entity that assigns the identification.
           $ref: "#/components/schemas/Max35Text"
       required:
         - Id
@@ -2783,10 +3383,19 @@ components:
       type: object
       properties:
         Id:
+          description: |
+            Identification
+            Identification assigned by an institution.
           $ref: "#/components/schemas/Max256Text"
         SchmeNm:
+          description: |-
+            SchemeName
+            Name of the identification scheme.
           $ref: "#/components/schemas/OrganisationIdentificationSchemeName1Choice"
         Issr:
+          description: |
+            Issuer
+            Entity that assigns the identification.
           $ref: "#/components/schemas/Max35Text"
       required:
         - Id
@@ -2800,10 +3409,19 @@ components:
       type: object
       properties:
         Id:
+          description: |
+            Identification
+            Unique and unambiguous identification of a person.
           $ref: "#/components/schemas/Max35Text"
         SchmeNm:
+          description: |
+            SchemeName
+            Name of the identification scheme.
           $ref: "#/components/schemas/PersonIdentificationSchemeName1Choice"
         Issr:
+          description: |
+            Issuer
+            Entity that assigns the identification.
           $ref: "#/components/schemas/Max35Text"
       required:
         - Id
@@ -2817,10 +3435,19 @@ components:
       type: object
       properties:
         Id:
+          description: |
+            Identification
+            Unique and unambiguous identification of a person.
           $ref: "#/components/schemas/Max256Text"
         SchmeNm:
+          description: |
+            SchemeName
+            Name of the identification scheme.
           $ref: "#/components/schemas/PersonIdentificationSchemeName1Choice"
         Issr:
+          description: |
+            Issuer
+            Entity that assigns the identification.
           $ref: "#/components/schemas/Max35Text"
       required:
         - Id
@@ -2834,10 +3461,23 @@ components:
       type: object
       properties:
         Assgnmt:
+          description: |
+            Assignment
+            Information related to the identification assignment.
           $ref: "#/components/schemas/IdentificationAssignment3"
         Rpt:
+          description: >
+            Report
+
+            Information concerning the verification of the identification data
+            for which verification was requested.
           $ref: "#/components/schemas/VerificationReport4"
         SplmtryData:
+          description: >
+            SupplementaryData
+
+            Additional information that cannot be captured in the structured
+            elements and/or any other specific block.
           $ref: "#/components/schemas/SupplementaryData1"
       required:
         - Assgnmt
@@ -2892,59 +3532,79 @@ components:
       type: object
       properties:
         Assgnmt:
+          description: |
+            Assignment
+            Identifies the identification assignment.
           $ref: "#/components/schemas/IdentificationAssignment3"
         Rpt:
+          description: >
+            Report
+
+            Information concerning the verification of the identification data
+            for which verification was requested.
           $ref: "#/components/schemas/VerificationReport4"
         SplmtryData:
+          description: >
+            SupplementaryData
+
+            Additional information that cannot be captured in the structured
+            elements and/or any other specific block.
           $ref: "#/components/schemas/SupplementaryData1"
       required:
         - Assgnmt
         - Rpt
       example:
         Assgnmt:
-          Id: 123
-          CreDtTm: "2013-03-07T16:30:00"
+          MsgId: 123
+          CreDtTm: "2020-01-01T00:00:00Z"
           Assgnr:
-            Id:
-              Id: 123
-              SchmeNm:
-                Cd: IBAN
-              Issr: BIC
+            OrgId:
+              Othr:
+                Id: 123
+                SchmeNm:
+                  Cd: BIC
+                Issr: BIC
           Assgne:
-            Id:
-              Id: 123
-              SchmeNm:
-                Cd: IBAN
-              Issr: BIC
+            OrgId:
+              Othr:
+                Id: DFSPID
         Rpt:
-          Id: 123
-          CreDtTm: "2013-03-07T16:30:00"
-          RptgPty:
-            Id:
-              Id: 123
-              SchmeNm:
-                Cd: IBAN
-              Issr: BIC
-          RptdPty:
-            Id:
-              Id: 123
-              SchmeNm:
-                Cd: IBAN
-              Issr: BIC
-          RptdDoc:
-            Nb: 123
-            RltdDt: "2013-03-07"
-            RltdDtTp:
-              Cd: 123
-          Rsn:
-            Cd: 123
-            Prtry: 123
-        SplmtryData:
-          PlcAndNm: 123
-          Envlp: 123
-          RltdDt: "2013-03-07"
-          RltdDtTp:
-            Cd: 123
+          OrgnlId: 12345678
+          Vrfctn: true
+          UpdtdPtyAndAcctId:
+            Pty:
+              Nm: John Doe
+              PstlAdr:
+                AdrTp: ADDR
+                Dept: Dept
+                SubDept: SubDept
+                StrtNm: StrtNm
+                BldgNb: BldgNb
+                BldgNm: BldgNm
+                Flr: Flr
+                PstBx: PstBx
+                Room: Room
+                PstCd: PstCd
+                TwnNm: TwnNm
+                TwnLctnNm: TwnLctnNm
+                DstrctNm: DstrctNm
+                CtrySubDvsn: CtrySubDvsn
+                Ctry: Ctry
+                AdrLine: AdrLine
+              Id:
+                OrgId:
+                  Othr:
+                    Id: 18761231234
+                  SchmeNm:
+                    Prtry: MSISDN
+              CtryOfRes: BE
+              CtctDtls:
+                NmPrfx: Mr
+                Nm: John Doe
+                PhneNb: +123-123-321
+                MobNb: +123-123-321
+                FaxNb: +123-123-321
+                EmailAdr: example@example.com
     GroupHeader113:
       title: GroupHeader113
       description: >
@@ -3186,10 +3846,23 @@ components:
         MsgId:
           $ref: "#/components/schemas/Max35Text"
         CreDtTm:
+          description: |
+            CreationDateTime
+            Date and time at which the identification assignment was created.
           $ref: "#/components/schemas/ISODateTime"
         Assgnr:
+          description: >
+            Assignor
+
+            Party that assigns the identification assignment to another party.
+            This is also the sender of the message.
           $ref: "#/components/schemas/Party40Choice"
         Assgne:
+          description: >
+            Assignee
+
+            Party that the identification assignment is assigned to. This is
+            also the receiver of the message.
           $ref: "#/components/schemas/Party40Choice"
       required:
         - MsgId
@@ -3218,10 +3891,21 @@ components:
       type: object
       properties:
         Pty:
+          description: >
+            Party
+
+            Account owner that owes an amount of money or to whom an amount of
+            money is due.
           $ref: "#/components/schemas/PartyIdentification135"
         Acct:
+          description: |
+            Account
+            Unambiguous identification of the account of a party.
           $ref: "#/components/schemas/CashAccount40"
         Agt:
+          description: |
+            Agent
+            Financial institution servicing an account for a party.
           $ref: "#/components/schemas/BranchAndFinancialInstitutionIdentification6"
       example:
         Pty:
@@ -3240,6 +3924,16 @@ components:
       title: IdentificationVerificationIndicator
       type: boolean
       example: true
+      description: >
+        Definition: Identifies whether the party and/or account information
+        received is correct.
+
+
+        • Meaning When True: Indicates that the identification information
+        received is correct.
+
+        • Meaning When False: Indicates that the identification information
+        received is incorrect
     Instruction4Code:
       title: Instruction4Code
       description: >
@@ -3265,8 +3959,20 @@ components:
       type: object
       properties:
         Cd:
+          description: >
+            Code
+
+            Coded information related to the processing of the payment
+            instruction, provided by the initiating party, and intended for the
+            creditor's agent.
           $ref: "#/components/schemas/ExternalCreditorAgentInstruction1Code"
         InstrInf:
+          description: >
+            InstructionInformation
+
+            Further information complementing the coded instruction or
+            instruction to the creditor's agent that is bilaterally agreed or
+            specific to a user community.
           $ref: "#/components/schemas/Max140Text"
       example:
         Cd: PHOA
@@ -3280,8 +3986,20 @@ components:
       type: object
       properties:
         Cd:
+          description: >
+            Code
+
+            Coded information related to the processing of the payment
+            instruction, provided by the initiating party, and intended for the
+            next agent in the payment chain.
           $ref: "#/components/schemas/Instruction4Code"
         InstrInf:
+          description: >
+            InstructionInformation
+
+            Further information complementing the coded instruction or
+            instruction to the next agent that is bilaterally agreed or specific
+            to a user community.
           $ref: "#/components/schemas/Max140Text"
       example:
         Cd: PHOA
@@ -3300,8 +4018,16 @@ components:
       type: object
       properties:
         Cd:
+          description: >
+            Code
+
+            Specifies the local instrument, as published in an external local
+            instrument code list.
           $ref: "#/components/schemas/ExternalLocalInstrument1Code"
         Prtry:
+          description: |
+            Proprietary
+            Specifies the local instrument, as a proprietary code
           $ref: "#/components/schemas/Max35Text"
       oneOf:
         - required:
@@ -3436,10 +4162,23 @@ components:
       type: object
       properties:
         AnyBIC:
+          description: |
+            AnyBIC
+            Business identification code of the organisation.
           $ref: "#/components/schemas/AnyBICDec2014Identifier"
         LEI:
+          description: >
+            LEI
+
+            Legal entity identification as an alternate identification for a
+            party.
           $ref: "#/components/schemas/LEIIdentifier"
         Othr:
+          description: >
+            Other
+
+            Unique identification of an organisation, as assigned by an
+            institution, using an identification scheme.
           $ref: "#/components/schemas/GenericOrganisationIdentification1"
       example:
         AnyBIC: BICFI
@@ -3456,10 +4195,23 @@ components:
       type: object
       properties:
         AnyBIC:
+          description: |
+            AnyBIC
+            Business identification code of the organisation.
           $ref: "#/components/schemas/AnyBICDec2014Identifier"
         LEI:
+          description: >
+            LEI
+
+            Legal entity identification as an alternate identification for a
+            party.
           $ref: "#/components/schemas/LEIIdentifier"
         Othr:
+          description: >
+            Other
+
+            Unique identification of an organisation, as assigned by an
+            institution, using an identification scheme.
           $ref: "#/components/schemas/GenericOrganisationIdentification3"
       example:
         AnyBIC: BICFI
@@ -3476,8 +4228,16 @@ components:
       type: object
       properties:
         Cd:
+          description: >
+            Code
+
+            Name of the identification scheme, in a coded form as published in
+            an external list.
           $ref: "#/components/schemas/ExternalOrganisationIdentification1Code"
         Prtry:
+          description: |
+            Proprietary
+            Name of the identification scheme, in a free text form.
           $ref: "#/components/schemas/Max35Text"
       oneOf:
         - required:
@@ -3494,8 +4254,16 @@ components:
       type: object
       properties:
         ChanlTp:
+          description: >
+            ChannelType
+
+            Method used to contact the financial institution's contact for the
+            specific tax region.
           $ref: "#/components/schemas/Max4Text"
         Id:
+          description: |
+            Identifier
+            Communication value such as phone number or email address.
           $ref: "#/components/schemas/Max128Text"
       required:
         - ChanlTp
@@ -3625,8 +4393,16 @@ components:
       type: object
       properties:
         OrgId:
+          description: |
+            Organisation
+            Unique and unambiguous way to identify an organisation.
           $ref: "#/components/schemas/OrganisationIdentification29"
         PrvtId:
+          description: >
+            PrivateIdentification
+
+            Unique and unambiguous identification of a person, for example a
+            passport.
           $ref: "#/components/schemas/PersonIdentification13"
       oneOf:
         - required:
@@ -3643,12 +4419,18 @@ components:
     Party40Choice:
       title: Party40Choice
       description: |
-        Nature or use of the account.
+        Identification of a person, an organisation or a financial institution.
       type: object
       properties:
         Pty:
+          description: |
+            Party
+            Identification of a person or an organisation.
           $ref: "#/components/schemas/PartyIdentification135"
         Agt:
+          description: |
+            Agent
+            Identification of a financial institution.
           $ref: "#/components/schemas/BranchAndFinancialInstitutionIdentification6"
       oneOf:
         - required:
@@ -3681,12 +4463,20 @@ components:
     Party52Choice:
       title: Party52Choice
       description: |
-        Nature or use of the account.
+        NOTE: Unsure on the description.
       type: object
       properties:
         OrgId:
+          description: |
+            Organisation
+            Unique and unambiguous way to identify an organisation.
           $ref: "#/components/schemas/OrganisationIdentification39"
         PrvtId:
+          description: >
+            Person
+
+            Unique and unambiguous identification of a person, for example a
+            passport
           $ref: "#/components/schemas/PersonIdentification18"
       oneOf:
         - required:
@@ -3707,26 +4497,54 @@ components:
       type: object
       properties:
         Nm:
+          description: >
+            Name by which a party is known and which is usually used to identify
+            that party.
           $ref: "#/components/schemas/Max140Text"
         PstlAdr:
+          description: >
+            Information that locates and identifies a specific address, as
+            defined by postal services.
           $ref: "#/components/schemas/PostalAddress24"
         Id:
+          description: |
+            Unique and unambiguous way to identify an organisation.
           $ref: "#/components/schemas/Party38Choice"
         CtryOfRes:
+          description: >
+            Country in which a person resides (the place of a person's home). In
+            the case of a company, it is the country from which the affairs of
+            that company are directed.
           $ref: "#/components/schemas/CountryCode"
         CtctDtls:
+          description: |
+            Set of elements used to indicate how to contact the party.
           $ref: "#/components/schemas/Contact4"
       example:
         Nm: John Doe
         PstlAdr:
-          Ctry: BE
-          AdrLine:
-            - Rue du Marché 45
-            - Brussels
-            - BE
+          AdrTp: ADDR
+          Dept: Dept
+          SubDept: SubDept
+          StrtNm: StrtNm
+          BldgNb: BldgNb
+          BldgNm: BldgNm
+          Flr: Flr
+          PstBx: PstBx
+          Room: Room
+          PstCd: PstCd
+          TwnNm: TwnNm
+          TwnLctnNm: TwnLctnNm
+          DstrctNm: DstrctNm
+          CtrySubDvsn: CtrySubDvsn
+          Ctry: Ctry
+          AdrLine: AdrLine
         Id:
           OrgId:
-            AnyBIC: CCCCUS33
+            Othr:
+              Id: 123
+              SchmeNm:
+                Prtry: DfspId
         CtryOfRes: BE
         CtctDtls:
           NmPrfx: Mr
@@ -3734,7 +4552,7 @@ components:
           PhneNb: +123-123-321
           MobNb: +123-123-321
           FaxNb: +123-123-321
-          EmailAdr: null
+          EmailAdr: example@example.com
     PartyIdentification272:
       title: PartyIdentification272
       description: |
@@ -3742,14 +4560,36 @@ components:
       type: object
       properties:
         Nm:
+          description: >
+            Name
+
+            Name by which a party is known and which is usually used to identify
+            that party.
           $ref: "#/components/schemas/Max140Text"
         PstlAdr:
+          description: >
+            Postal Address
+
+            Information that locates and identifies a specific address, as
+            defined by postal services.
           $ref: "#/components/schemas/PostalAddress27"
         Id:
+          description: |
+            Identification
+            Unique and unambiguous identification of a party.
           $ref: "#/components/schemas/Party52Choice"
         CtryOfRes:
+          description: >
+            Country of Residence
+
+            Country in which a person resides (the place of a person's home). In
+            the case of a company, it is the country from which the affairs of
+            that company are directed.
           $ref: "#/components/schemas/CountryCode"
         CtctDtls:
+          description: |
+            Contact Details
+            Set of elements used to indicate how to contact the party.
           $ref: "#/components/schemas/Contact13"
       example:
         Nm: John Doe
@@ -3785,14 +4625,63 @@ components:
       type: object
       properties:
         InstrId:
+          description: >
+            InstructionIdentification
+
+            Definition: Unique identification, as assigned by an instructing
+            party for an instructed party, to unambiguously identify the
+            instruction.
+
+            Usage: The instruction identification is a point to point reference
+            that can be used between the instructing party and the instructed
+            party to refer to the individual instruction. It can be included in
+            several messages related to the instruction.
           $ref: "#/components/schemas/Max35Text"
         EndToEndId:
+          description: >
+            EndToEndIdentification
+
+            Definition: Unique identification, as assigned by the initiating
+            party, to unambiguously identify the transaction. This
+            identification is passed on, unchanged, throughout the entire
+            end-to-end chain.
+
+            Usage: The end-to-end identification can be used for reconciliation
+            or to link tasks relating to the transaction. It can be included in
+            several messages related to the transaction.
+
+            Usage: In case there are technical limitations to pass on multiple
+            references, the end-to-end identification must be passed on
+            throughout the entire end-to-end chain.
           $ref: "#/components/schemas/Max35Text"
         TxId:
+          description: >
+            TransactionIdentification
+
+            Definition: Unique identification, as assigned by the first
+            instructing agent, to unambiguously identify the transaction that is
+            passed on, unchanged, throughout the entire interbank chain.
+
+            Usage: The transaction identification can be used for
+            reconciliation, tracking or to link tasks relating to the
+            transaction on the interbank level.
+
+            Usage: The instructing agent has to make sure that the transaction
+            identification is unique for a preagreed period.
           $ref: "#/components/schemas/Max35Text"
         UETR:
+          description: >
+            UETR
+
+            Universally unique identifier to provide an end-to-end reference of
+            a payment transaction.
           $ref: "#/components/schemas/UUIDv4Identifier"
         ClrSysRef:
+          description: >
+            ClearingSystemReference
+
+            Unique reference, as assigned by a clearing system, to unambiguously
+            identify the instruction.
           $ref: "#/components/schemas/Max35Text"
       required:
         - EndToEndId
@@ -3857,14 +4746,42 @@ components:
       type: object
       properties:
         InstrPrty:
+          description: >
+            InstructionPriority
+
+            Indicator of the urgency or order of importance that the instructing
+            party would like the instructed party to apply to the processing of
+            the instruction.
           $ref: "#/components/schemas/Priority2Code"
         ClrChanl:
+          description: >
+            ClearingChannel
+
+            SSpecifies the clearing channel to be used to process the payment
+            instruction.
           $ref: "#/components/schemas/ClearingChannel2Code"
         SvcLvl:
+          description: >
+            ServiceLevel
+
+            Agreement under which or rules under which the transaction should be
+            processed.
           $ref: "#/components/schemas/ServiceLevel8Choice"
         LclInstrm:
+          description: >
+            LocalInstrument
+
+            Definition: User community specific instrument.
+
+            Usage: This element is used to specify a local instrument, local
+            clearing option and/or further qualify the service or service level.
           $ref: "#/components/schemas/LocalInstrument2Choice"
         CtgyPurp:
+          description: >
+            CategoryPurpose
+
+            Specifies the high level purpose of the instruction based on a set
+            of pre-defined categories.
           $ref: "#/components/schemas/CategoryPurpose1Choice"
       example:
         InstrPrty: NORM
@@ -3887,8 +4804,16 @@ components:
       type: object
       properties:
         DtAndPlcOfBirth:
+          description: |
+            DateAndPlaceOfBirth
+            Date and place of birth of a person.
           $ref: "#/components/schemas/DateAndPlaceOfBirth1"
         Othr:
+          description: >
+            Other
+
+            Unique identification of a person, as assigned by an institution,
+            using an identification scheme.
           $ref: "#/components/schemas/GenericPersonIdentification1"
       example:
         DtAndPlcOfBirth:
@@ -3906,8 +4831,16 @@ components:
       type: object
       properties:
         DtAndPlcOfBirth:
+          description: |
+            DateAndPlaceOfBirth
+            Date and place of birth of a person.
           $ref: "#/components/schemas/DateAndPlaceOfBirth1"
         Othr:
+          description: >
+            Other
+
+            Unique identification of a person, as assigned by an institution,
+            using an identification scheme.
           $ref: "#/components/schemas/GenericPersonIdentification2"
       example:
         DtAndPlcOfBirth:
@@ -3925,8 +4858,16 @@ components:
       type: object
       properties:
         Cd:
+          description: >
+            Code
+
+            Name of the identification scheme, in a coded form as published in
+            an external list
           $ref: "#/components/schemas/ExternalPersonIdentification1Code"
         Prtry:
+          description: |
+            Proprietary
+            Name of the identification scheme, in a free text form
           $ref: "#/components/schemas/Max35Text"
       oneOf:
         - required:
@@ -4103,8 +5044,18 @@ components:
       type: object
       properties:
         Tp:
+          description: |
+            Type
+
+            Type of the proxy identification.
           $ref: "#/components/schemas/ProxyAccountType1Choice"
         Id:
+          description: >
+            Identification
+
+
+            Identification used to indicate the account identification under
+            another specified name.
           $ref: "#/components/schemas/Max2048Text"
       required:
         - Id
@@ -4116,11 +5067,23 @@ components:
       title: ProxyAccountType1Choice
       type: object
       description: |
-        NOTE: Unsure on description.
+        ProxyAccountType1Choice
+
+        Specifies the scheme used for the identification of an account alias.
       properties:
         Cd:
+          description: >
+            Code
+
+
+            Name of the identification scheme, in a coded form as published in
+            an external list.
           $ref: "#/components/schemas/ExternalProxyAccountType1Code"
         Prtry:
+          description: |
+            Proprietary
+
+            Name of the identification scheme, in a free text form.
           $ref: "#/components/schemas/Max35Text"
       oneOf:
         - required:
@@ -4141,8 +5104,18 @@ components:
       type: object
       properties:
         Cd:
+          description: >
+            Code
+
+
+            Underlying reason for the payment transaction, as published in an
+            external purpose code list.
           $ref: "#/components/schemas/ExternalPurpose1Code"
         Prtry:
+          description: |
+            Proprietary
+
+            Purpose, in a proprietary form.
           $ref: "#/components/schemas/Max35Text"
       oneOf:
         - required:
@@ -4159,8 +5132,18 @@ components:
       type: object
       properties:
         Nm:
+          description: |
+            Name
+
+            Name of the entity requiring the regulatory reporting information.
           $ref: "#/components/schemas/Max140Text"
         Ctry:
+          description: >
+            Country
+
+
+            Country of the entity that requires the regulatory reporting
+            information.
           $ref: "#/components/schemas/CountryCode"
       example:
         Nm: Swiss National Bank
@@ -4172,11 +5155,31 @@ components:
       type: object
       properties:
         DbtCdtRptgInd:
+          description: >
+            DebitCreditReportingIndicator
+
+            Identifies whether the regulatory reporting information applies to
+            the debit side, to the credit side or to both debit and credit sides
+            of the transaction.
           $ref: "#/components/schemas/RegulatoryReportingType1Code"
         Authrty:
+          description: |
+            Authority
+
+            Entity requiring the regulatory reporting information.
           $ref: "#/components/schemas/RegulatoryAuthority2"
         Dtls:
-          $ref: "#/components/schemas/StructuredRegulatoryReporting3"
+          description: >
+            Details
+
+            Identifies whether the regulatory reporting information applies to
+            the debit side, to the credit side or to both debit and credit sides
+            of the transaction.
+          anyOf:
+            - $ref: "#/components/schemas/StructuredRegulatoryReporting3"
+            - items:
+                $ref: "#/components/schemas/StructuredRegulatoryReporting3"
+              type: array
       example:
         DbtCdtRptgInd: CRED
         Authrty:
@@ -4204,8 +5207,18 @@ components:
       type: object
       properties:
         Cd:
+          description: >
+            Code
+
+            Specifies a pre-agreed service or level of service between the
+            parties, as published in an external service level code list.
           $ref: "#/components/schemas/ExternalServiceLevel1Code"
         Prtry:
+          description: >
+            Proprietary
+
+            Specifies a pre-agreed service or level of service between the
+            parties, as a proprietary code.
           $ref: "#/components/schemas/Max35Text"
       oneOf:
         - required:
@@ -4216,13 +5229,21 @@ components:
         Cd: SEPA
     SettlementInstruction15:
       title: SettlementInstruction15
-      description: |
-        NOTE: Unsure on description.
+      description: >
+        Specifies the details on how the settlement of the original
+        transaction(s) between the
+
+        instructing agent and the instructed agent was completed.
       type: object
       properties:
         SttlmMtd:
+          description: |
+            SettlementMethod
+            Method used to settle the (batch of) payment instructions.
           $ref: "#/components/schemas/SettlementMethod1Code"
         PmtTpInf:
+          description: |
+            PaymentTypeInformation
           $ref: "#/components/schemas/PaymentTypeInformation28"
       required:
         - SttlmMtd
@@ -4273,8 +5294,14 @@ components:
       type: object
       properties:
         Cd:
+          description: |
+            Code
+            Reason for the status, as published in an external reason code list.
           $ref: "#/components/schemas/ExternalStatusReason1Code"
         Prtry:
+          description: |
+            Proprietary
+            Reason for the status, in a proprietary form.
           $ref: "#/components/schemas/Max35Text"
       oneOf:
         - required:
@@ -4290,10 +5317,19 @@ components:
       type: object
       properties:
         Orgtr:
+          description: |-
+            Originator
+            Party that issues the status.
           $ref: "#/components/schemas/PartyIdentification272"
         Rsn:
+          description: |-
+            Reason
+            Specifies the reason for the status report.
           $ref: "#/components/schemas/StatusReason6Choice"
         AddtlInf:
+          description: |-
+            AdditionalInformation
+            Additional information about the status report.
           $ref: "#/components/schemas/Max105Text"
       example:
         Orgtr:
@@ -4314,21 +5350,59 @@ components:
     StructuredRegulatoryReporting3:
       title: StructuredRegulatoryReporting3
       description: |
-        Unsure on description.
+        StructuredRegulatoryReporting3
+
+        Information needed due to regulatory and statutory requirements.
       type: object
       properties:
         Tp:
+          description: >
+            Type
+
+
+            Specifies the type of the information supplied in the regulatory
+            reporting details.
           $ref: "#/components/schemas/Max35Text"
         Dt:
+          description: |
+            Date
+
+            Date related to the specified type of regulatory reporting details.
           $ref: "#/components/schemas/ISODate"
         Ctry:
+          description: >
+            Country
+
+
+            Country related to the specified type of regulatory reporting
+            details.
           $ref: "#/components/schemas/CountryCode"
         Cd:
+          description: >
+            Code
+
+            Specifies the nature, purpose, and reason for the transaction to be
+            reported for regulatory and statutory requirements in a coded form.
           $ref: "#/components/schemas/Max10Text"
         Amt:
+          description: >
+            Amount
+
+
+            Amount of money to be reported for regulatory and statutory
+            requirements.
           $ref: "#/components/schemas/ActiveOrHistoricCurrencyAndAmount"
         Inf:
-          $ref: "#/components/schemas/Max35Text"
+          description: >
+            Information
+
+            Additional details that cater for specific domestic regulatory
+            requirements.
+          anyOf:
+            - $ref: "#/components/schemas/Max35Text"
+            - items:
+                $ref: "#/components/schemas/Max35Text"
+              type: array
       example:
         Tp: T1
         Dt: "2018-01-01"
@@ -4346,8 +5420,21 @@ components:
       type: object
       properties:
         PlcAndNm:
+          description: >
+            PlaceAndName
+
+            Unambiguous reference to the location where the supplementary data
+            must be inserted in the message instance.
           $ref: "#/components/schemas/Max350Text"
         Envlp:
+          description: >
+            Envelope
+
+            Technical element wrapping the supplementary data.
+
+            Technical component that contains the validated supplementary data
+            information. This technical envelope allows to segregate the
+            supplementary data information from any other information.
           $ref: "#/components/schemas/SupplementaryDataEnvelope1"
       required:
         - Envlp
@@ -4358,8 +5445,12 @@ components:
           Prtry: Additional information
     SupplementaryDataEnvelope1:
       title: SupplementaryDataEnvelope1
-      description: |
-        Unsure on description.
+      description: >
+        SupplementaryDataEnvelope1
+
+        Technical component that contains the validated supplementary data
+        information. This technical envelope allows to segregate the
+        supplementary data information from any other information.
       type: object
     TaxAmount3:
       title: TaxAmount3
@@ -4368,13 +5459,37 @@ components:
       type: object
       properties:
         Rate:
+          description: |
+            Rate
+
+            Rate used to calculate the tax.
           $ref: "#/components/schemas/PercentageRate"
         TaxblBaseAmt:
+          description: |
+            TaxableBaseAmount
+
+            Amount of money on which the tax is based.
           $ref: "#/components/schemas/ActiveOrHistoricCurrencyAndAmount"
         TtlAmt:
+          description: >
+            TotalAmount
+
+
+            Total amount that is the result of the calculation of the tax for
+            the record.
           $ref: "#/components/schemas/ActiveOrHistoricCurrencyAndAmount"
         Dtls:
-          $ref: "#/components/schemas/TaxRecordDetails3"
+          description: >
+            Details
+
+
+            Set of elements used to provide details on the tax period and
+            amount.
+          anyOf:
+            - $ref: "#/components/schemas/TaxRecordDetails3"
+            - items:
+                $ref: "#/components/schemas/TaxRecordDetails3"
+              type: array
       example:
         Rate: 0
         TaxblBaseAmt:
@@ -4398,8 +5513,18 @@ components:
       type: object
       properties:
         Titl:
+          description: >
+            Title
+
+
+            Title or position of debtor or the debtor's authorised
+            representative.
           $ref: "#/components/schemas/Max35Text"
         Nm:
+          description: |
+            Name
+
+            Name of the debtor or the debtor's authorised representative.
           $ref: "#/components/schemas/Max140Text"
       example:
         Titl: Mr
@@ -4413,27 +5538,81 @@ components:
       type: object
       properties:
         Cdtr:
+          description: >
+            Creditor
+
+
+            Party on the credit side of the transaction to which the tax
+            applies.
           $ref: "#/components/schemas/TaxParty1"
         Dbtr:
+          description: |
+            Debtor
+
+            Party on the debit side of the transaction to which the tax applies.
           $ref: "#/components/schemas/TaxParty2"
         UltmtDbtr:
+          description: >
+            UltimateDebtor
+
+
+            Ultimate party that owes an amount of money to the (ultimate)
+            creditor, in this case, to the taxing authority.
           $ref: "#/components/schemas/TaxParty2"
         AdmstnZone:
+          description: |
+            AdministrationZone
+
+            Territorial part of a country to which the tax payment is related.
           $ref: "#/components/schemas/Max35Text"
         RefNb:
+          description: |
+            ReferenceNumber
+
+            Tax reference information that is specific to a taxing agency.
           $ref: "#/components/schemas/Max140Text"
         Mtd:
+          description: >
+            Method
+
+
+            Method used to indicate the underlying business or how the tax is
+            paid.
           $ref: "#/components/schemas/Max35Text"
         TtlTaxblBaseAmt:
+          description: |
+            TotalTaxableBaseAmount
+
+            Total amount of money on which the tax is based.
           $ref: "#/components/schemas/ActiveOrHistoricCurrencyAndAmount"
         TtlTaxAmt:
+          description: |
+            TotalTaxAmount
+
+            Total amount of money as result of the calculation of the tax.
           $ref: "#/components/schemas/ActiveOrHistoricCurrencyAndAmount"
         Dt:
+          description: |
+            Date
+
+            Date by which tax is due.
           $ref: "#/components/schemas/ISODate"
         SeqNb:
+          description: |
+            SequenceNumber
+
+            Sequential number of the tax report
           $ref: "#/components/schemas/Number"
         Rcrd:
-          $ref: "#/components/schemas/TaxRecord3"
+          description: |
+            Record
+
+            Details of the tax record.
+          anyOf:
+            - $ref: "#/components/schemas/TaxRecord3"
+            - items:
+                $ref: "#/components/schemas/TaxRecord3"
+              type: array
       example:
         Cdtr:
           Titl: Mr
@@ -4470,10 +5649,24 @@ components:
       type: object
       properties:
         TaxId:
+          description: |
+            TaxIdentification
+
+            Tax identification number of the creditor.
           $ref: "#/components/schemas/Max35Text"
         RegnId:
+          description: >
+            RegistrationIdentification
+
+
+            Unique identification, as assigned by an organisation, to
+            unambiguously identify a party.
           $ref: "#/components/schemas/Max35Text"
         TaxTp:
+          description: |
+            TaxType
+
+            Type of tax payer.
           $ref: "#/components/schemas/Max35Text"
       example:
         TaxId: 123456789
@@ -4486,12 +5679,30 @@ components:
       type: object
       properties:
         TaxId:
+          description: |
+            TaxIdentification
+
+            Tax identification number of the debtor.
           $ref: "#/components/schemas/Max35Text"
         RegnId:
+          description: >
+            RegistrationIdentification
+
+
+            Unique identification, as assigned by an organisation, to
+            unambiguously identify a party.
           $ref: "#/components/schemas/Max35Text"
         TaxTp:
+          description: |
+            TaxType
+
+            Type of tax payer.
           $ref: "#/components/schemas/Max35Text"
         Authstn:
+          description: |
+            Authorisation
+
+            Details of the authorised tax paying party.
           $ref: "#/components/schemas/TaxAuthorisation1"
       example:
         TaxId: 123456789
@@ -4506,12 +5717,26 @@ components:
         Period of time details related to the tax payment.
       type: object
       properties:
-        Yr:
-          $ref: "#/components/schemas/ISOYear"
-        Tp:
-          $ref: "#/components/schemas/TaxRecordPeriod1Code"
         FrToDt:
           $ref: "#/components/schemas/DatePeriod2"
+          description: >
+            FromToDate
+
+
+            Range of time between a start date and an end date for which the tax
+            report is provided.
+        Tp:
+          $ref: "#/components/schemas/TaxRecordPeriod1Code"
+          description: |
+            Type
+
+            Identification of the period related to the tax payment.
+        Yr:
+          $ref: "#/components/schemas/ISOYear"
+          description: |
+            Year
+
+            Year related to the tax payment.
       example:
         Yr: 2020
         Tp: MM01
@@ -4524,24 +5749,70 @@ components:
         Set of elements used to define the tax record.
       type: object
       properties:
-        Tp:
-          $ref: "#/components/schemas/Max35Text"
-        Ctgy:
-          $ref: "#/components/schemas/Max35Text"
-        CtgyDtls:
-          $ref: "#/components/schemas/Max35Text"
-        DbtrSts:
-          $ref: "#/components/schemas/Max35Text"
-        CertId:
-          $ref: "#/components/schemas/Max35Text"
-        FrmsCd:
-          $ref: "#/components/schemas/Max35Text"
-        Prd:
-          $ref: "#/components/schemas/TaxPeriod3"
-        TaxAmt:
-          $ref: "#/components/schemas/TaxAmount3"
         AddtlInf:
           $ref: "#/components/schemas/Max140Text"
+          description: |
+            AdditionalInformation
+
+            Further details of the tax record.
+        CertId:
+          $ref: "#/components/schemas/Max35Text"
+          description: >
+            CertificateIdentification
+
+
+            Identification number of the tax report as assigned by the taxing
+            authority.
+        Ctgy:
+          $ref: "#/components/schemas/Max35Text"
+          description: |
+            Category
+
+            Specifies the tax code as published by the tax authority.
+        CtgyDtls:
+          $ref: "#/components/schemas/Max35Text"
+          description: |
+            CategoryDetails
+
+            Provides further details of the category tax code.
+        DbtrSts:
+          $ref: "#/components/schemas/Max35Text"
+          description: >
+            DebtorStatus
+
+
+            Code provided by local authority to identify the status of the party
+            that has drawn up the settlement document.
+        FrmsCd:
+          $ref: "#/components/schemas/Max35Text"
+          description: >
+            FormsCode
+
+
+            Identifies, in a coded form, on which template the tax report is to
+            be provided.
+        Prd:
+          $ref: "#/components/schemas/TaxPeriod3"
+          description: >
+            Period
+
+
+            Set of elements used to provide details on the period of time
+            related to the tax payment.
+        TaxAmt:
+          $ref: "#/components/schemas/TaxAmount3"
+          description: >
+            TaxAmount
+
+
+            Set of elements used to provide information on the amount of the tax
+            record.
+        Tp:
+          $ref: "#/components/schemas/Max35Text"
+          description: |
+            Type
+
+            High level code to identify the type of tax details.
       example:
         Tp: VAT
         Ctgy: A
@@ -4564,8 +5835,18 @@ components:
       type: object
       properties:
         Prd:
+          description: >
+            Period
+
+
+            Set of elements used to provide details on the period of time
+            related to the tax payment.
           $ref: "#/components/schemas/TaxPeriod3"
         Amt:
+          description: |
+            Amount
+
+            Underlying tax amount related to the specified period.
           $ref: "#/components/schemas/ActiveOrHistoricCurrencyAndAmount"
       required:
         - Amt
@@ -4688,8 +5969,18 @@ components:
       type: object
       properties:
         Cd:
+          description: >
+            Code
+
+            Reason why the verified identification information is incorrect, as
+            published in an external reason code list.
           $ref: "#/components/schemas/ExternalVerificationReason1Code"
         Prtry:
+          description: >
+            Proprietary
+
+            Reason why the verified identification information is incorrect, in
+            a free text form.
           $ref: "#/components/schemas/Max35Text"
       oneOf:
         - required:
@@ -4703,31 +5994,81 @@ components:
       type: object
       properties:
         OrgnlId:
+          description: >
+            OriginalIdentification
+
+            Unique identification, as assigned by a sending party, to
+            unambiguously identify the party and account identification
+            information group within the original message.
           $ref: "#/components/schemas/Max35Text"
         Vrfctn:
+          description: >
+            Verification
+
+            Identifies whether the party and/or account information received is
+            correct. Boolean value.
           $ref: "#/components/schemas/IdentificationVerificationIndicator"
         Rsn:
+          description: >
+            Reason.
+
+            Specifies the reason why the verified identification information is
+            incorrect.
           $ref: "#/components/schemas/VerificationReason1Choice"
         OrgnlPtyAndAcctId:
+          description: >
+            OriginalPartyAndAccountIdentification
+
+            Provides party and/or account identification information as given in
+            the original message.
           $ref: "#/components/schemas/IdentificationInformation4"
         UpdtdPtyAndAcctId:
+          description: |
+            UpdatedPartyAndAccountIdentification
+            Provides party and/or account identification information.
           $ref: "#/components/schemas/IdentificationInformation4"
       required:
         - OrgnlId
         - Vrfctn
       example:
-        OrgnlId: 123456789
+        OrgnlId: 1.2345678901234568e+33
         Vrfctn: true
-        Rsn:
-          Cd: AGNT
         OrgnlPtyAndAcctId:
-          Id: 123456789
-          SchmeNm:
-            Cd: CCPT
+          Nm: John Doe
+          PstlAdr:
+            AdrTp: ADDR
+            Dept: Dept
+            SubDept: SubDept
+            StrtNm: 1234 Elm St
+            BldgNb: 1234
+            PstCd: 12345
+            TwnNm: Anytown
+            CtrySubDvsn: CA
+            Ctry: US
+          Id:
+            OrgId:
+              AnyBIC: ABCDUS33
+              Othr:
+                Id: 123456789
+                Issr: ABA
         UpdtdPtyAndAcctId:
-          Id: 123456789
-          SchmeNm:
-            Cd: CCPT
+          Nm: John Doe
+          PstlAdr:
+            AdrTp: ADDR
+            Dept: Dept
+            SubDept: SubDept
+            StrtNm: 1234 Elm St
+            BldgNb: 1234
+            PstCd: 12345
+            TwnNm: Anytown
+            CtrySubDvsn: CA
+            Ctry: US
+          Id:
+            OrgId:
+              AnyBIC: ABCDUS33
+              Othr:
+                Id: 123456789
+                Issr: ABA
     hexBinary:
       title: hexBinary
       type: string

--- a/docs/fspiop-rest-v2.0-ISO20022-openapi3-snippets.yaml
+++ b/docs/fspiop-rest-v2.0-ISO20022-openapi3-snippets.yaml
@@ -1693,7 +1693,7 @@ components:
       properties:
         Id:
           description: >
-            identification
+            Identification
 
             Unique and unambiguous identification of a branch of a financial
             institution.
@@ -2235,11 +2235,11 @@ components:
             the processing of the payment transaction.
           $ref: "#/components/schemas/ChargeBearerType1Code"
         ChrgsInf:
-          description: |
+          description: >
             ChargesInformation
 
-             Provides information on the charges to be paid by the charge bearer(s) related to the
-            payment transaction
+            Provides information on the charges to be paid by the charge
+            bearer(s) related to the payment transaction
           $ref: "#/components/schemas/Charges16"
         Dbtr:
           description: |
@@ -3017,80 +3017,78 @@ components:
         - GrpHdr
       example:
         GrpHdr:
-          MsgId: 123456789
+          MsgId: 12345
           CreDtTm: "2020-01-01T00:00:00Z"
           NbOfTxs: 1
-          CtrlSum: 100
-          InitgPty:
-            Nm: Initiating Party Name
-            Id:
-              OrgId:
-                Othr:
-                  - Id: 123456789
-                    SchmeNm:
-                      Cd: BIC
-          FwdgAgt:
-            FinInstnId:
-              BICFI: BICFID0
-          Dbtr:
-            Nm: Debtor Name
-            PstlAdr:
-              AdrLine:
-                - Debtor Address Line 1
-                - Debtor Address Line 2
-            Id:
-              OrgId:
-                Othr:
-                  - Id: 123456789
-                    SchmeNm:
-                      Cd: BIC
-          DbtrAcct:
-            Id:
-              IBAN: BE71096123456769
-          DbtrAgt:
-            FinInstnId:
-              BICFI: BICFID0
-          Cdtr:
-            Nm: Creditor Name
-            PstlAdr:
-              AdrLine:
-                - Creditor Address Line 1
-                - Creditor Address Line 2
-            Id:
-              OrgId:
-                Othr:
-                  - Id: 123456789
-                    SchmeNm:
-                      Cd: BIC
-          CdtrAcct:
-            Id:
-              IBAN: BE71096123456769
-          CdtrAgt:
-            FinInstnId:
-              BICFI: BICFID0
+          TtlIntrBkSttlmAmt:
+            Ccy: EUR
+            Value: 100
+          SttlmInf:
+            SttlmMtd: INDA
+            SttlmAcct:
+              Id:
+                IBAN: BE71096123456769
+              Ccy: EUR
+            SttlmAcctOwnr:
+              Nm: Name
+            SttlmAcctSvcr:
+              Nm: Name
+            SttlmAgt:
+              FinInstnId:
+                BICFI: BIC
+          PmtTpInf:
+            InstrPrty: NORM
+            CtgyPurp: CASH
           CdtTrfTxInf:
-            - PmtId:
-                InstrId: 123456789
-                EndToEndId: 123456789
-              Amt:
-                InstdAmt:
-                  Ccy: EUR
-                  Amt: 100
-              CdtrAgt:
-                FinInstnId:
-                  BICFI: BICFID0
-              Cdtr:
-                Nm: Creditor Name
-                PstlAdr:
-                  AdrLine:
-                    - Creditor Address Line 1
-                    - Creditor Address Line 2
+            PmtId:
+              InstrId: 12345
+              EndToEndId: 12345
+            Amt:
+              InstdAmt:
+                Ccy: EUR
+                Value: 100
+            Cdtr:
+              Nm: Name
+            CdtrAcct:
+              Id:
+                IBAN: BE71096123456769
+              Ccy: EUR
+            CdtrAgt:
+              FinInstnId:
+                BICFI: BIC
+            Dbtr:
+              Nm: Name
+            DbtrAcct:
+              Id:
+                IBAN: BE71096123456769
+              Ccy: EUR
+            DbtrAgt:
+              FinInstnId:
+                BICFI: BIC
+            IntrBkSttlmAmt:
+              Ccy: EUR
+              Value: 100
+            PmtTpInf:
+              InstrPrty: NORM
+              ClrChanl: RTGS
+              SvcLvl:
+                Cd: SEPA
+              LclInstrm:
+                Cd: CORE
+              CtgyPurp:
+                Cd: CASH
+            RgltryRptg:
+              Dbtr:
+                Nm: Name
+              DbtrAcct:
                 Id:
-                  OrgId:
-                    Othr:
-                      - Id: 123456789
-                        SchmeNm:
-                          Cd: BIC
+                  IBAN: BE71096123456769
+                Ccy: EUR
+              DbtrAgt:
+                FinInstnId:
+                  BICFI: BIC
+              Cdtr:
+                Nm: Name
     FxResponse_FICreditTransferConfirmation:
       title: FxResponse_FICreditTransferConfirmation
       type: object
@@ -3686,10 +3684,32 @@ components:
       type: object
       properties:
         MsgId:
+          description: >
+            MessageIdentification
+
+            Definition: Point to point reference, as assigned by the instructing
+            party, and sent to the next party in the chain to unambiguously
+            identify the message.
+
+            Usage: The instructing party has to make sure that
+            MessageIdentification is unique per instructed party for a
+            pre-agreed period.
           $ref: "#/components/schemas/Max35Text"
         CreDtTm:
+          description: |
+            CreationDateTime
+            Date and time at which the message was created.
           $ref: "#/components/schemas/ISODateTime"
         TxInfAndSts:
+          description: >
+            TransactionInformationAndStatus
+
+            Definition: Agent that instructs the next party in the chain to
+            carry out the (set of) instruction(s).
+
+            Usage: The instructing agent is the party sending the status message
+            and not the party that sent the original instruction that is being
+            reported on.
           $ref: "#/components/schemas/PaymentTransaction163"
       required:
         - MsgId
@@ -4318,74 +4338,25 @@ components:
         - GrpHdr
       example:
         GrpHdr:
-          MsgId: 123
+          MsgId: 12345
           CreDtTm: "2020-01-01T00:00:00Z"
-          NbOfTxs: 1
-          SttlmInf:
-            SttlmMtd: INDA
-            SttlmDt: "2020-01-01"
-            SttlmTmIndctn: RTGS
-            SttlmTmReq: "2020-01-01T00:00:00Z"
-            SttlmAcct:
-              Id:
-                Othr:
-                  Id: 123
-                  SchmeNm:
-                    Cd: IBAN
-                  Issr: BIC
-            ClrSys:
-              Prtry: 123
-            InstgAgt:
-              FinInstnId:
-                BICFI: 123
-            InstdAgt:
-              FinInstnId:
-                BICFI: 123
-          InstgAgt:
-            FinInstnId:
-              BICFI: 123
-          InstdAgt:
-            FinInstnId:
-              BICFI: 123
-          IntrBkSttlmAmt:
-            Amt: 123
-            Ccy: EUR
-          IntrBkSttlmDt: "2020-01-01"
-          TxSts: ACCP
-          StsRsnInf:
-            Orgtr:
-              Id:
-                Othr:
-                  Id: 123
-                  SchmeNm:
-                    Cd: IBAN
-                  Issr: BIC
-            Rsn:
-              Cd: 123
-              Prtry: 123
           TxInfAndSts:
-            OrgnlInstrId: 123
-            OrgnlEndToEndId: 123
-            TxSts: ACCP
+            StsId: 12345
+            OrgnlInstrId: 12345
+            OrgnlEndToEndId: 12345
+            OrgnlTxId: 12345
+            OrgnlUETR: 123e4567-e89b-12d3-a456-426614174000
+            TxSts: RJCT
             StsRsnInf:
-              Orgtr:
-                Id:
-                  Othr:
-                    Id: 123
-                    SchmeNm:
-                      Cd: IBAN
-                    Issr: BIC
-              Rsn:
-                Cd: 123
-                Prtry: 123
-            ChrgsInf:
-              Amt: 123
-              Ccy: EUR
-            IntrBkSttlmAmt:
-              Amt: 123
-              Ccy: EUR
-            IntrBkSttlmDt: "2020-01-01"
-            SttlmTmIndctn: RTGS
+              Rsn: RSN
+              AddtlInf: ADDITIONAL
+            AccptncDtTm: "2020-01-01T00:00:00Z"
+            AcctSvcrRef: ACCTSVCRREF
+            ClrSysRef: CLRSYSREF
+            ExctnConf: 1234567890ABCDEF
+            SplmtryData:
+              PlcAndNm: PLACE
+              Envlp: ENVELOPE
     Party38Choice:
       title: Party38Choice
       description: |
@@ -4498,26 +4469,32 @@ components:
       properties:
         Nm:
           description: >
+            Name
+
             Name by which a party is known and which is usually used to identify
             that party.
           $ref: "#/components/schemas/Max140Text"
         PstlAdr:
           description: >
+            PostalAddress
+
             Information that locates and identifies a specific address, as
             defined by postal services.
           $ref: "#/components/schemas/PostalAddress24"
         Id:
           description: |
+            Identification
             Unique and unambiguous way to identify an organisation.
           $ref: "#/components/schemas/Party38Choice"
         CtryOfRes:
           description: >
-            Country in which a person resides (the place of a person's home). In
-            the case of a company, it is the country from which the affairs of
-            that company are directed.
+            CountryOfResidence Country in which a person resides (the place of a
+            person's home). In the case of a company, it is the country from
+            which the affairs of that company are directed.
           $ref: "#/components/schemas/CountryCode"
         CtctDtls:
           description: |
+            ContactDetails
             Set of elements used to indicate how to contact the party.
           $ref: "#/components/schemas/Contact4"
       example:
@@ -4757,7 +4734,7 @@ components:
           description: >
             ClearingChannel
 
-            SSpecifies the clearing channel to be used to process the payment
+            Specifies the clearing channel to be used to process the payment
             instruction.
           $ref: "#/components/schemas/ClearingChannel2Code"
         SvcLvl:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/AccountIdentification4Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/AccountIdentification4Choice.yaml
@@ -5,8 +5,20 @@ description: >
   servicer.
 properties:
   IBAN:
+    description: >
+      IBAN
+
+      International Bank Account Number (IBAN) - identifier used internationally by financial
+      institutions to uniquely identify the account of a customer. Further specifications of the format and
+      content of the IBAN can be found in the standard ISO 13616 "Banking and related financial services -
+      International Bank Account Number (IBAN)" version 1997-10-01, or later revisions.
     $ref: ./IBAN2007Identifier.yaml
   Othr:
+    description: >
+      Other
+
+      Unique identification of an account, as assigned by the account servicer, using an
+      identification scheme.
     $ref: ./GenericAccountIdentification1.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/AccountSchemeName1Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/AccountSchemeName1Choice.yaml
@@ -4,8 +4,16 @@ description: |
   Sets of elements to identify a name of the identification scheme.
 properties:
   Cd:
+    description: >
+      Code
+
+      Name of the identification scheme, in a coded form as published in an external list.
     $ref: ./ExternalAccountIdentification1Code.yaml
   Prtry:
+    description: >
+      Proprietary
+
+      Name of the identification scheme, in a free text form.
     $ref: ./Max35Text.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/ActiveCurrencyAndAmount.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/ActiveCurrencyAndAmount.yaml
@@ -7,6 +7,10 @@ properties:
   ActiveCurrencyAndAmount:
     $ref: ./ActiveCurrencyAndAmount_SimpleType.yaml
   Ccy:
+    description: >
+      Currency
+
+      Identification of the currency in which the account is held.
     $ref: ./ActiveCurrencyCode.yaml
 required:
   - ActiveCurrencyAndAmount

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/ActiveOrHistoricCurrencyAndAmount.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/ActiveOrHistoricCurrencyAndAmount.yaml
@@ -7,6 +7,10 @@ properties:
   ActiveOrHistoricCurrencyAndAmount:
     $ref: ./ActiveOrHistoricCurrencyAndAmount_SimpleType.yaml
   Ccy:
+    description: >
+      Currency
+
+      Identification of the currency in which the account is held.
     $ref: ./ActiveOrHistoricCurrencyCode.yaml
 required:
   - ActiveOrHistoricCurrencyAndAmount

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/AddressType2Code.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/AddressType2Code.yaml
@@ -1,5 +1,6 @@
 description: |
   AddressType2Code
+
   Specifies the type of address.
 enum:
   - ADDR

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/AddressType3Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/AddressType3Choice.yaml
@@ -4,8 +4,16 @@ description: |
   Choice of formats for the type of address.
 properties:
   Cd:
+    description: >
+      Code
+
+      Type of address expressed as a code.
     $ref: ./AddressType2Code.yaml
   Prtry:
+    description: >
+      Proprietary
+
+      Type of address expressed as a proprietary code.
     $ref: ./GenericIdentification30.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/BranchAndFinancialInstitutionIdentification6.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/BranchAndFinancialInstitutionIdentification6.yaml
@@ -5,8 +5,20 @@ description: >
   of a financial institution.
 properties:
   FinInstnId:
+    description: >
+      FinancialInstitutionIdentification
+
+      Unique and unambiguous identification of a financial institution, as assigned under an
+      internationally recognised or proprietary identification scheme.
     $ref: ./FinancialInstitutionIdentification18.yaml
   BrnchId:
+    description: >
+      BranchIdentification
+
+      Definition: Identifies a specific branch of a financial institution.
+
+      Usage: This component should be used in case the identification information in the financial institution
+      component does not provide identification up to branch level.
     $ref: ./BranchData3.yaml
 required:
   - FinInstnId

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/BranchAndFinancialInstitutionIdentification8.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/BranchAndFinancialInstitutionIdentification8.yaml
@@ -5,20 +5,34 @@ description: >
   of a financial institution.
 properties:
   FinInstnId:
+    description: >
+      FinancialInstitutionIdentification
+
+      Unique and unambiguous identification of a financial institution or a branch of a financial
+      institution.
     $ref: ./FinancialInstitutionIdentification23.yaml
   BrnchId:
+    description: >
+      BranchIdentification
+
+       Identifies a specific branch of a financial institution.
     $ref: ./BranchData5.yaml
 required:
   - FinInstnId
 example:
   FinInstnId:
-    BICFI: BUKBGB22
+    BICFI: J5BMVH7D
   BrnchId:
-    Id: 12345
-    Nm: Oxford Street Branch
+    Id: 123
+    Nm: Name
     PstlAdr:
-      Ctry: GB
-      AdrLine:
-        - 1 Oxford Street
-        - London
-        - UK
+      AdrTp: ADDR
+      Dept: Department
+      SubDept: Sub department
+      StrtNm: Street name
+      BldgNb: Building number
+      PstCd: Post code
+      TwnNm: Town name
+      CtrySubDvsn: Country subdivision
+      Ctry: Country
+      AdrLine: Address line

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/BranchData3.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/BranchData3.yaml
@@ -5,12 +5,28 @@ description: >
   institution.
 properties:
   Id:
+    description: >
+      Identification
+
+      Unique and unambiguous identification of a branch of a financial institution.
     $ref: ./Max35Text.yaml
   LEI:
+    description: >
+      Legal Entity Identifier
+
+      Legal entity identification for the branch of the financial institution.
     $ref: ./LEIIdentifier.yaml
   Nm:
+    description: >
+      Name
+
+      Name by which an agent is known and which is usually used to identify that agent.
     $ref: ./Max140Text.yaml
   PstlAdr:
+    description: >
+      Postal Address
+
+      Information that locates and identifies a specific address, as defined by postal services.
     $ref: ./PostalAddress24.yaml
 example:
   Id: 123

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/BranchData5.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/BranchData5.yaml
@@ -6,7 +6,7 @@ type: object
 properties:
   Id:
     description: >
-      identification
+      Identification
 
       Unique and unambiguous identification of a branch of a financial institution.
     $ref: ./Max35Text.yaml

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/BranchData5.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/BranchData5.yaml
@@ -5,19 +5,41 @@ description: >
 type: object
 properties:
   Id:
+    description: >
+      identification
+
+      Unique and unambiguous identification of a branch of a financial institution.
     $ref: ./Max35Text.yaml
   LEI:
+    description: >
+      LEI
+
+      Legal entity identification for the branch of the financial institution.
     $ref: ./LEIIdentifier.yaml
   Nm:
+    description: >
+      Name
+
+      Name by which an agent is known and which is usually used to identify that agent.
     $ref: ./Max140Text.yaml
   PstlAdr:
+    description: >
+      PostalAddress
+
+      Information that locates and identifies a specific address, as defined by postal services.
     $ref: ./PostalAddress27.yaml
 example:
   Id: 123
-  Nm: Oxford Street Branch
+  LEI: 123
+  Nm: Name
   PstlAdr:
-    Ctry: GB
-    AdrLine:
-      - 1 Oxford Street
-      - London
-      - UK
+    AdrTp: ADDR
+    Dept: Department
+    SubDept: Sub department
+    StrtNm: Street name
+    BldgNb: Building number
+    PstCd: Post code
+    TwnNm: Town name
+    CtrySubDvsn: Country subdivision
+    Ctry: Country
+    AdrLine: Address line

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/CashAccount40.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/CashAccount40.yaml
@@ -4,14 +4,43 @@ description: |
   Provides the details to identify an account.
 properties:
   Id:
+    description: >
+      Identification
+
+      Unique and unambiguous identification for the account between the account owner and the
+      account servicer.
     $ref: ./AccountIdentification4Choice.yaml
   Tp:
+    description: >
+      Type
+
+      Specifies the nature, or use of the account.
     $ref: ./CashAccountType2Choice.yaml
   Ccy:
+    description: >
+      Currency
+
+      Definition: Identification of the currency in which the account is held.
+
+      Usage: Currency should only be used in case one and the same account number covers several
+      currencies and the initiating party needs to identify which currency needs to be used for settlement on the account.
     $ref: ./ActiveOrHistoricCurrencyCode.yaml
   Nm:
+    description: >
+      Name
+
+      Definition: Name of the account, as assigned by the account servicing institution, in agreement with the
+      account owner in order to provide an additional means of identification of the account.
+
+      Usage: The account name is different from the account owner name. The account name is used in
+      certain user communities to provide a means of identifying the account, in addition to the account
+      owner's identity and the account number.
     $ref: ./Max70Text.yaml
   Prxy:
+    description: >
+      Proxy
+
+      Specifies an alternate assumed name for the identification of the account.
     $ref: ./ProxyAccountIdentification1.yaml
 example:
   Id:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/CashAccountType2Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/CashAccountType2Choice.yaml
@@ -4,8 +4,16 @@ description: |
 type: object
 properties:
   Cd:
+    description: >
+      Code
+
+      Account type, in a coded form.
     $ref: ./ExternalCashAccountType1Code.yaml
   Prtry:
+    description: >
+      Proprietary
+
+      Nature or use of the account in a proprietary form.
     $ref: ./Max35Text.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/CategoryPurpose1Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/CategoryPurpose1Choice.yaml
@@ -5,8 +5,16 @@ description: >
 type: object
 properties:
   Cd:
+    description: >
+      Code
+
+      Category purpose, as published in an external category purpose code list.
     $ref: ./ExternalCategoryPurpose1Code.yaml
   Prtry:
+    description: >
+      Proprietary
+
+      Category purpose, in a proprietary form.
     $ref: ./Max35Text.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/ChargeType3Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/ChargeType3Choice.yaml
@@ -1,10 +1,21 @@
 title: ChargeType3Choice
-description: ChargeType3Choice Specifies the type of charge.
+description: >
+  ChargeType3Choice
+
+  Specifies the type of charge.
 type: object
 properties:
   Cd:
+    description: >
+      Code
+
+      Charge type, in a coded form.
     $ref: ./ExternalChargeType1Code.yaml
   Prtry:
+    description: >
+      Proprietary
+
+      Type of charge in a proprietary form, as defined by the issuer.
     $ref: ./GenericIdentification3.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/Charges16.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/Charges16.yaml
@@ -1,13 +1,27 @@
 title: Charges16
 description: |
   NOTE: Unsure on description.
+
+  Seemingly a generic schema for charges, with an amount, agent, and type.
 type: object
 properties:
   Amt:
+    description: >
+      Amount
+
+       Transaction charges to be paid by the charge bearer.
     $ref: ./ActiveOrHistoricCurrencyAndAmount.yaml
   Agt:
+    description: >
+      Agent
+
+      Agent that takes the transaction charges or to which the transaction charges are due.
     $ref: ./BranchAndFinancialInstitutionIdentification8.yaml
   Tp:
+    description: >
+      Type
+
+       Defines the type of charges.
     $ref: ./ChargeType3Choice.yaml
 required:
   - Amt

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/ClearingSystemIdentification2Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/ClearingSystemIdentification2Choice.yaml
@@ -4,8 +4,17 @@ description: |
 type: object
 properties:
   Cd:
+    description: >
+      Code
+
+      Identification of a member of a clearing system
     $ref: ./ExternalClearingSystemIdentification1Code.yaml
   Prtry:
+    description: >
+      Proprietary
+
+      Identification code for a clearing system, that has not yet been identified in the list of clearing
+      systems.
     $ref: ./Max35Text.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/ClearingSystemMemberIdentification2.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/ClearingSystemMemberIdentification2.yaml
@@ -5,8 +5,17 @@ description: >
 type: object
 properties:
   ClrSysId:
+    description: >
+      ClearingSystemIdentification.
+
+      Specification of a pre-agreed offering between clearing agents or the channel through which
+      the payment instruction is processed.
     $ref: ./ClearingSystemIdentification2Choice.yaml
   MmbId:
+    description: >
+      MemberIdentification.
+
+      Identification of a member of a clearing system.
     $ref: ./Max35Text.yaml
 required:
   - MmbId

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/Contact13.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/Contact13.yaml
@@ -4,30 +4,83 @@ description: |
 type: object
 properties:
   NmPrfx:
+    description: >
+      NamePrefix
+
+      Specifies the terms used to formally address a person.
     $ref: ./NamePrefix2Code.yaml
   Nm:
+    description: >
+      Name
+
+      Name by which a party is known and which is usually used to identify that party.
     $ref: ./Max140Text.yaml
   PhneNb:
+    description: >
+      PhoneNumber
+
+      Collection of information that identifies a phone number, as defined by telecom services.
     $ref: ./PhoneNumber.yaml
   MobNb:
+    description: >
+      MobilePhoneNumber
+
+      Collection of information that identifies a mobile phone number, as defined by telecom services.
     $ref: ./PhoneNumber.yaml
   FaxNb:
+    description: >
+      FaxNumber
+
+      Collection of information that identifies a fax number, as defined by telecom services.
     $ref: ./PhoneNumber.yaml
   URLAdr:
+    description: >
+      URLAddress
+
+      Address for the Universal Resource Locator (URL), for example an address used over the
+      www (HTTP) service.
     $ref: ./Max2048Text.yaml
   EmailAdr:
+    description: >
+      EmailAddress
+
+      Address for electronic mail (e-mail).
     $ref: ./Max256Text.yaml
   EmailPurp:
+    description: >
+      EmailPurpose
+
+      Purpose for which an email address may be used.
     $ref: ./Max35Text.yaml
   JobTitl:
+    description: >
+      JobTitle
+
+      Title of the function.
     $ref: ./Max35Text.yaml
   Rspnsblty:
+    description: >
+      Responsibility
+
+      Role of a person in an organisation.
     $ref: ./Max35Text.yaml
   Dept:
+    description: >
+      Department
+
+      Identification of a division of a large organisation or building.
     $ref: ./Max70Text.yaml
   Othr:
+    description: >
+      OtherContact
+
+      Contact details in another form.
     $ref: ./OtherContact1.yaml
   PrefrdMtd:
+    description: >
+      PreferredContactMethod
+
+      Preferred method used to reach the contact.
     $ref: ./PreferredContactMethod2Code.yaml
 example:
   NmPrfx: Mr

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/Contact4.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/Contact4.yaml
@@ -4,28 +4,76 @@ description: |
 type: object
 properties:
   NmPrfx:
+    description: >
+      NamePrefix
+
+      Name prefix to be used before the name of the person.
     $ref: ./NamePrefix2Code.yaml
   Nm:
+    description: >
+      Name
+
+      Name by which a party is known and which is usually used to identify that party.
     $ref: ./Max140Text.yaml
   PhneNb:
+    description: >
+      PhoneNumber
+
+      Collection of information that identifies a phone number, as defined by telecom services.
     $ref: ./PhoneNumber.yaml
   MobNb:
+    description: >
+      MobilePhoneNumber
+
+      Collection of information that identifies a mobile phone number, as defined by telecom services.
     $ref: ./PhoneNumber.yaml
   FaxNb:
+    description: >
+      FaxNumber
+
+      Collection of information that identifies a fax number, as defined by telecom services.
     $ref: ./PhoneNumber.yaml
   EmailAdr:
+    description: >
+      EmailAddress
+
+      Address for electronic mail (e-mail).
     $ref: ./Max2048Text.yaml
   EmailPurp:
+    description: >
+      EmailPurpose
+
+      Purpose for which an email address may be used.
     $ref: ./Max35Text.yaml
   JobTitl:
+    description: >
+      JobTitle
+
+      Title of the function.
     $ref: ./Max35Text.yaml
   Rspnsblty:
+    description: >
+      Responsibility
+
+      Role of a person in an organisation.
     $ref: ./Max35Text.yaml
   Dept:
+    description: >
+      Department
+
+      Identification of a division of a large organisation or building.
     $ref: ./Max70Text.yaml
   Othr:
+    description: >
+      Other
+
+      : Contact details in another form.
     $ref: ./OtherContact1.yaml
   PrefrdMtd:
+    description: >
+      PreferredMethod
+
+      Preferred method used to reach the contact.
     $ref: ./PreferredContactMethod1Code.yaml
 example:
   NmPrfx: Mr

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/CountryCode.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/CountryCode.yaml
@@ -2,3 +2,6 @@ title: CountryCode
 type: string
 pattern: ^[A-Z]{2,2}$
 example: US
+description: >
+  Code to identify a country, a dependency, or another area of particular geopolitical interest,
+  on the basis of country names obtained from the United Nations (ISO 3166, Alpha-2 code).

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/CreditTransferTransaction67.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/CreditTransferTransaction67.yaml
@@ -47,7 +47,7 @@ properties:
     description: >
       ChargesInformation
 
-       Provides information on the charges to be paid by the charge bearer(s) related to the
+      Provides information on the charges to be paid by the charge bearer(s) related to the
       payment transaction
     $ref: ./Charges16.yaml
   Dbtr:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/CreditTransferTransaction67.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/CreditTransferTransaction67.yaml
@@ -5,40 +5,118 @@ description: >
 type: object
 properties:
   PmtId:
+    description: >
+      PaymentIdentification
+
+      Set of elements used to reference a payment instruction.
     $ref: ./PaymentIdentification13.yaml
   PmtTpInf:
+    description: >
+      PaymentTypeInformation
+
+       Set of elements used to further specify the type of transaction.
     $ref: ./PaymentTypeInformation28.yaml
   IntrBkSttlmAmt:
+    description: >
+      InterbankSettlementAmount
+
+      Amount of money moved between the instructing agent and the instructed agent.
     $ref: ./ActiveCurrencyAndAmount.yaml
   InstdAmt:
+    description: >
+      InstructedAmount
+
+      Amount of money to be moved between the debtor and creditor,
+      before deduction of charges, expressed in the currency as ordered by the initiating party.
     $ref: ./ActiveOrHistoricCurrencyAndAmount.yaml
   XchgRate:
+    description: >
+      ExchangeRate
+
+      Factor used to convert an amount from one currency into another. This reflects the price at
+      which one currency was bought with another currency.
     $ref: ./BaseOneRate.yaml
   ChrgBr:
+    description: >
+      ChargeBearer
+
+      Specifies which party/parties will bear the charges associated with the processing of the
+      payment transaction.
     $ref: ./ChargeBearerType1Code.yaml
   ChrgsInf:
+    description: >
+      ChargesInformation
+
+       Provides information on the charges to be paid by the charge bearer(s) related to the
+      payment transaction
     $ref: ./Charges16.yaml
   Dbtr:
+    description: >
+      Debtor
+
+      Party that owes an amount of money to the (ultimate) creditor.
     $ref: ./PartyIdentification272.yaml
   DbtrAcct:
+    description: >
+      DebtorAccount
+
+      Unambiguous identification of the account of the debtor to which a debit entry will be made
+      as a result of the transaction.
     $ref: ./CashAccount40.yaml
   DbtrAgt:
+    description: >
+      DebtorAgent
+
+      Financial institution servicing an account for the debtor.
     $ref: ./BranchAndFinancialInstitutionIdentification8.yaml
   CdtrAgt:
+    description: >
+      CreditorAgent
+
+      Financial institution servicing an account for the creditor.
     $ref: ./BranchAndFinancialInstitutionIdentification8.yaml
   Cdtr:
+    description: >
+      Creditor
+
+      Party to which an amount of money is due.
     $ref: ./PartyIdentification272.yaml
   CdtrAcct:
+    description: >
+      CreditorAccount
+
+      Unambiguous identification of the account of the creditor to which a credit entry will be
+      posted as a result of the payment transaction.
     $ref: ./CashAccount40.yaml
   InstrForCdtrAgt:
+    description: >
+      InstructionForCreditorAgent
+
+      Set of elements used to provide information on the remittance advice.
     $ref: ./InstructionForCreditorAgent3.yaml
   InstrForNxtAgt:
+    description: >
+      InstructionForNextAgent
+
+      Set of elements used to provide information on the remittance advice.
     $ref: ./InstructionForNextAgent1.yaml
   Purp:
+    description: >
+      Purpose
+
+      Underlying reason for the payment transaction.
     $ref: ./Purpose2Choice.yaml
   RgltryRptg:
+    description: >
+      RegulatoryReporting
+
+      Information needed due to regulatory and statutory requirements.
     $ref: ./RegulatoryReporting3.yaml
   Tax:
+    description: >
+      Tax
+
+      Provides details on the tax.
     $ref: ./TaxData1.yaml
   VrfctnOfTerms:
     $ref: ./CryptographicLockChoice.yaml

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/CreditTransferTransaction68.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/CreditTransferTransaction68.yaml
@@ -5,28 +5,76 @@ description: >
 type: object
 properties:
   PmtId:
+    description: >
+      PaymentIdentification
+
+      Set of elements used to reference a payment instruction.
     $ref: ./PaymentIdentification13.yaml
   PmtTpInf:
+    description: >
+      PaymentTypeInformation
+
+       Set of elements used to further specify the type of transaction.
     $ref: ./PaymentTypeInformation28.yaml
   IntrBkSttlmAmt:
+    description: >
+      InterbankSettlementAmount
+
+      Amount of money moved between the instructing agent and the instructed agent.
     $ref: ./ActiveCurrencyAndAmount.yaml
   Dbtr:
+    description: >
+      Debtor
+
+      Party that owes an amount of money to the (ultimate) creditor.
     $ref: ./BranchAndFinancialInstitutionIdentification8.yaml
   DbtrAcct:
+    description: >
+      DebtorAccount
+
+      Account used to process a payment.
     $ref: ./CashAccount40.yaml
   DbtrAgt:
+    description: >
+      DebtorAgent
+
+      Financial institution servicing an account for the debtor.
     $ref: ./BranchAndFinancialInstitutionIdentification8.yaml
   CdtrAgt:
+    description: >
+      CreditorAgent
+
+      Financial institution servicing an account for the creditor.
     $ref: ./BranchAndFinancialInstitutionIdentification8.yaml
   Cdtr:
+    description: >
+      Creditor
+
+      Party to which an amount of money is due.
     $ref: ./BranchAndFinancialInstitutionIdentification8.yaml
   CdtrAcct:
+    description: >
+      CreditorAccount
+
+      Account to which a credit entry is made.
     $ref: ./CashAccount40.yaml
   InstrForCdtrAgt:
+    description: >
+      InstructionForCreditorAgent
+
+      Set of elements used to provide information on the remittance advice.
     $ref: ./InstructionForCreditorAgent3.yaml
   Purp:
+    description: >
+      Purpose
+
+      Underlying reason for the payment transaction.
     $ref: ./Purpose2Choice.yaml
   VrfctnOfTerms:
+    description: >
+      VerificationOfTerms
+
+      Set of elements used to provide information on the underlying terms of the transaction.
     $ref: ./CryptographicLockChoice.yaml
 required:
   - PmtId

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/DateAndPlaceOfBirth1.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/DateAndPlaceOfBirth1.yaml
@@ -4,12 +4,28 @@ description: |
 type: object
 properties:
   BirthDt:
+    description: >
+      BirthDate
+
+      Date on which a person is born.
     $ref: ./ISODate.yaml
   PrvcOfBirth:
+    description: >
+      ProvinceOfBirth
+
+      Province where a person was born.
     $ref: ./Max35Text.yaml
   CityOfBirth:
+    description: >
+      CityOfBirth
+
+      City where a person was born.
     $ref: ./Max35Text.yaml
   CtryOfBirth:
+    description: >
+      CountryOfBirth
+
+      Country where a person was born.
     $ref: ./CountryCode.yaml
 required:
   - BirthDt

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/DatePeriod2.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/DatePeriod2.yaml
@@ -4,12 +4,20 @@ description: |
 type: object
 properties:
   FrDt:
+    description: >
+      FromDate
+
+      Start date of the range.
     $ref: ./ISODate.yaml
   ToDt:
+    description: >
+      ToDate
+
+      End date of the range.
     $ref: ./ISODate.yaml
 required:
   - FrDt
   - ToDt
 example:
-  FrDt: 2020-01-01
-  ToDt: 2020-12-31
+  FrDt: '2022-01-01T00:00:00.000Z'
+  ToDt: '2022-12-31T23:59:59.999Z'

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/Execute_FIToFICustomerCreditTransferV13.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/Execute_FIToFICustomerCreditTransferV13.yaml
@@ -2,60 +2,68 @@ title: Execute_FIToFICustomerCreditTransferV13
 type: object
 properties:
   GrpHdr:
+    description: >
+      GroupHeader.
     $ref: ./GroupHeader129.yaml
   CdtTrfTxInf:
+    description: >
+      CreditTransferTransactionInformation.
     $ref: ./CreditTransferTransaction67.yaml
 required:
   - GrpHdr
   - CdtTrfTxInf
 example:
   GrpHdr:
-    MsgId: 123456789
-    CreDtTm: 2020-01-01T00:00:00Z
+    MsgId: 12345
+    CreDtTm: '2020-01-01T00:00:00Z'
+    PmtInstrXpryDtTm: '2020-01-01T00:00:00Z'
     NbOfTxs: 1
-    CtrlSum: 100.00
-    InitgPty:
-      Nm: Initiating Party Name
-      Id:
-        OrgId:
-          Othr:
-            - Id: 123456789
-              SchmeNm:
-                Cd: 91
-    FwdgAgt:
-      FinInstnId:
-        BICFI: BBBBBBBB
+    SttlmInf:
+      SttlmMtd: INDA
+      SttlmAcct:
+        Id:
+          IBAN: 123
+      SttlmAcctOwnr:
+        Nm: John Doe
+      SttlmAcctSvcr:
+        BICFI: 123
+    CdtTrfTxInf:
+      PmtId:
+        InstrId: 123
+        EndToEndId: 123
+      PmtTpInf:
+        InstrPrty: NORM
+      InstdAmt:
+        Amt: 123
+        Ccy: EUR
+      ChrgBr: SLEV
+      CdtrAgt:
+        FinInstnId:
+          BICFI: 123
+      Cdtr:
+        Nm: John Doe
+      CdtrAcct:
+        Id:
+          IBAN: 123
+      RmtInf:
+        Ustrd: Test
   CdtTrfTxInf:
     PmtId:
-      InstrId: 123456789
-      EndToEndId: 123456789
+      InstrId: 123
+      EndToEndId: 123
     PmtTpInf:
       InstrPrty: NORM
-      CtgyPurp:
-        Cd: SUPP
-    InstrForCdtrAgt:
-      FinInstnId:
-        BICFI: AAAAAAAA
+    InstdAmt:
+      Amt: 123
+      Ccy: EUR
+    ChrgBr: SLEV
     CdtrAgt:
       FinInstnId:
-        BICFI: AAAAAAAA
+        BICFI: 123
     Cdtr:
-      Nm: Creditor Name
-      PstlAdr:
-        AdrLine:
-          - Creditor Address Line 1
-          - Creditor Address Line 2
-          - Creditor Address Line 3
-          - Creditor Address Line 4
-          - Creditor Address Line 5
-      Id:
-        OrgId:
-          Othr:
-            - Id: 123456789
-              SchmeNm:
-                Cd: 91
+      Nm: John Doe
     CdtrAcct:
       Id:
-        IBAN: DE87123456781234567890
+        IBAN: 123
     RmtInf:
-      Ustrd: Remittance Information
+      Ustrd: Test

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/FinancialIdentificationSchemeName1Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/FinancialIdentificationSchemeName1Choice.yaml
@@ -2,8 +2,16 @@ title: FinancialIdentificationSchemeName1Choice
 type: object
 properties:
   Cd:
+    description: >
+      Code
+
+      Name of the identification scheme, in a coded form as published in an external list.
     $ref: ./ExternalFinancialInstitutionIdentification1Code.yaml
   Prtry:
+    description: >
+      Proprietary
+
+      Name of the identification scheme, in a free text form.
     $ref: ./Max35Text.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/FinancialInstitutionIdentification18.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/FinancialInstitutionIdentification18.yaml
@@ -2,23 +2,64 @@ title: FinancialInstitutionIdentification18
 type: object
 properties:
   BICFI:
+    description: >
+      BICFI
+
+      Code allocated to a financial institution by the ISO 9362 Registration Authority as described
+      in ISO 9362 "Banking - Banking telecommunication messages - Business identifier code (BIC)"
     $ref: ./BICFIDec2014Identifier.yaml
   ClrSysMmbId:
+    description: >
+      ClearingSystemMemberIdentification
+
+      Information used to identify a member within a clearing system
     $ref: ./ClearingSystemMemberIdentification2.yaml
   LEI:
+    description: >
+      LEI
+
+      Legal entity identifier of the financial institution.
     $ref: ./LEIIdentifier.yaml
   Nm:
+    description: >
+      Name
+
+      Name by which an agent is known and which is usually used to identify that agent
     $ref: ./Max140Text.yaml
   PstlAdr:
+    description: >
+      PostalAddress
+
+      Information that locates and identifies a specific address, as defined by postal services.
     $ref: ./PostalAddress24.yaml
   Othr:
+    description: >
+      Other
+
+      Unique identification of an agent, as assigned by an institution, using an identification
+      scheme.
     $ref: ./GenericFinancialIdentification1.yaml
 example:
-  BICFI: BUKBGB22
-  Nm: Barclays Bank Plc
+  BICFI: J5BMVH7D
+  ClrSysMmbId:
+    ClrSysId: 1234
+    MmbId: 123
+  LEI: 123
+  Nm: Name
   PstlAdr:
-    Ctry: GB
-    AdrLine:
-      - 1 Churchill Place
-      - London
-      - UK
+    AdrTp: ADDR
+    Dept: Department
+    SubDept: Sub department
+    StrtNm: Street name
+    BldgNb: Building number
+    PstCd: Post code
+    TwnNm: Town name
+    CtrySubDvsn: Country subdivision
+    Ctry: Country
+    AdrLine: Address line
+  Othr:
+    Id: 123
+    SchmeNm:
+      Cd: 123
+      Prtry: 123
+    Issr: 123

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/FinancialInstitutionIdentification23.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/FinancialInstitutionIdentification23.yaml
@@ -2,23 +2,64 @@ title: FinancialInstitutionIdentification23
 type: object
 properties:
   BICFI:
+    description: >
+      BICFI
+
+      Code allocated to a financial institution by the ISO 9362 Registration Authority as described
+      in ISO 9362 "Banking - Banking telecommunication messages - Business identifier code (BIC)"
     $ref: ./BICFIDec2014Identifier.yaml
   ClrSysMmbId:
+    description: >
+      ClearingSystemMemberIdentification
+
+      Information used to identify a member within a clearing system
     $ref: ./ClearingSystemMemberIdentification2.yaml
   LEI:
+    description: >
+      LEI
+
+      Legal entity identifier of the financial institution.
     $ref: ./LEIIdentifier.yaml
   Nm:
+    description: >
+      Name
+
+      Name by which an agent is known and which is usually used to identify that agent
     $ref: ./Max140Text.yaml
   PstlAdr:
+    description: >
+      PostalAddress
+
+      Information that locates and identifies a specific address, as defined by postal services.
     $ref: ./PostalAddress27.yaml
   Othr:
+    description: >
+      Other
+
+      Unique identification of an agent, as assigned by an institution, using an identification
+      scheme.
     $ref: ./GenericFinancialIdentification1.yaml
 example:
-  BICFI: BUKBGB22
-  Nm: Barclays Bank Plc
+  BICFI: J5BMVH7D
+  ClrSysMmbId:
+    ClrSysId:
+      Cd: CHQB
+    MmbId: 123456789
+  LEI: 123
+  Nm: Name
   PstlAdr:
-    Ctry: GB
-    AdrLine:
-      - 1 Churchill Place
-      - London
-      - UK
+    AdrTp: ADDR
+    Dept: Department
+    SubDept: Sub department
+    StrtNm: Street name
+    BldgNb: Building number
+    PstCd: Post code
+    TwnNm: Town name
+    CtrySubDvsn: Country subdivision
+    Ctry: Country
+    AdrLine: Address line
+  Othr:
+    Id: 123
+    SchmeNm:
+      Cd: CHQB
+    Issr: 123

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/FxRequest_FICreditTransferProposal.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/FxRequest_FICreditTransferProposal.yaml
@@ -2,6 +2,10 @@ title: FxRequest_FICreditTransferProposal
 type: object
 properties:
   GrpHdr:
+    description: >
+      GroupHeader
+
+      Set of characteristics shared by all individual transactions included in the message.
     $ref: ./GroupHeader113.yaml
 required:
   - GrpHdr

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/FxRequest_FICreditTransferProposal.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/FxRequest_FICreditTransferProposal.yaml
@@ -11,77 +11,75 @@ required:
   - GrpHdr
 example:
   GrpHdr:
-    MsgId: 123456789
+    MsgId: 12345
     CreDtTm: '2020-01-01T00:00:00Z'
     NbOfTxs: 1
-    CtrlSum: 100.00
-    InitgPty:
-      Nm: Initiating Party Name
-      Id:
-        OrgId:
-          Othr:
-            - Id: 123456789
-              SchmeNm:
-                Cd: BIC
-    FwdgAgt:
-      FinInstnId:
-        BICFI: BICFID0
-    Dbtr:
-      Nm: Debtor Name
-      PstlAdr:
-        AdrLine:
-          - Debtor Address Line 1
-          - Debtor Address Line 2
-      Id:
-        OrgId:
-          Othr:
-            - Id: 123456789
-              SchmeNm:
-                Cd: BIC
-    DbtrAcct:
-      Id:
-        IBAN: BE71096123456769
-    DbtrAgt:
-      FinInstnId:
-        BICFI: BICFID0
-    Cdtr:
-      Nm: Creditor Name
-      PstlAdr:
-        AdrLine:
-          - Creditor Address Line 1
-          - Creditor Address Line 2
-      Id:
-        OrgId:
-          Othr:
-            - Id: 123456789
-              SchmeNm:
-                Cd: BIC
-    CdtrAcct:
-      Id:
-        IBAN: BE71096123456769
-    CdtrAgt:
-      FinInstnId:
-        BICFI: BICFID0
+    TtlIntrBkSttlmAmt:
+      Ccy: EUR
+      Value: 100.0
+    SttlmInf:
+      SttlmMtd: INDA
+      SttlmAcct:
+        Id:
+          IBAN: BE71096123456769
+        Ccy: EUR
+      SttlmAcctOwnr:
+        Nm: Name
+      SttlmAcctSvcr:
+        Nm: Name
+      SttlmAgt:
+        FinInstnId:
+          BICFI: BIC
+    PmtTpInf:
+      InstrPrty: NORM
+      CtgyPurp: CASH
     CdtTrfTxInf:
-      - PmtId:
-          InstrId: 123456789
-          EndToEndId: 123456789
-        Amt:
-          InstdAmt:
-            Ccy: EUR
-            Amt: 100.00
-        CdtrAgt:
-          FinInstnId:
-            BICFI: BICFID0
-        Cdtr:
-          Nm: Creditor Name
-          PstlAdr:
-            AdrLine:
-              - Creditor Address Line 1
-              - Creditor Address Line 2
+      PmtId:
+        InstrId: 12345
+        EndToEndId: 12345
+      Amt:
+        InstdAmt:
+          Ccy: EUR
+          Value: 100.0
+      Cdtr:
+        Nm: Name
+      CdtrAcct:
+        Id:
+          IBAN: BE71096123456769
+        Ccy: EUR
+      CdtrAgt:
+        FinInstnId:
+          BICFI: BIC
+      Dbtr:
+        Nm: Name
+      DbtrAcct:
+        Id:
+          IBAN: BE71096123456769
+        Ccy: EUR
+      DbtrAgt:
+        FinInstnId:
+          BICFI: BIC
+      IntrBkSttlmAmt:
+        Ccy: EUR
+        Value: 100.0
+      PmtTpInf:
+        InstrPrty: NORM
+        ClrChanl: RTGS
+        SvcLvl:
+          Cd: SEPA
+        LclInstrm:
+          Cd: CORE
+        CtgyPurp:
+          Cd: CASH
+      RgltryRptg:
+        Dbtr:
+          Nm: Name
+        DbtrAcct:
           Id:
-            OrgId:
-              Othr:
-                - Id: 123456789
-                  SchmeNm:
-                    Cd: BIC
+            IBAN: BE71096123456769
+          Ccy: EUR
+        DbtrAgt:
+          FinInstnId:
+            BICFI: BIC
+        Cdtr:
+          Nm: Name

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/FxResponse_FICreditTransferConfirmation.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/FxResponse_FICreditTransferConfirmation.yaml
@@ -2,8 +2,16 @@ title: FxResponse_FICreditTransferConfirmation
 type: object
 properties:
   GrpHdr:
+    description: >
+      GroupHeader
+
+      Set of characteristics shared by all individual transactions included in the message.
     $ref: ./GroupHeader113.yaml
   CdtTrfTxInf:
+    description: >
+      CreditTransferTransactionInformation
+
+      Set of elements providing information specific to the individual credit transfer(s).
     $ref: ./CreditTransferTransaction68.yaml
 required:
   - GrpHdr

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/Fxecute_FinancialInstitutionCreditTransferV12.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/Fxecute_FinancialInstitutionCreditTransferV12.yaml
@@ -2,8 +2,16 @@ title: Fxecute_FinancialInstitutionCreditTransferV12
 type: object
 properties:
   GrpHdr:
+    description: >
+      GroupHeader.
+
+      Set of characteristics shared by all individual transactions included in the message.
     $ref: ./GroupHeader129.yaml
   CdtTrfTxInf:
+    description: >
+      CreditTransferTransactionInformation.
+
+      Set of elements providing information specific to the individual credit transfer(s).
     $ref: ./CreditTransferTransaction68.yaml
 required:
   - GrpHdr
@@ -11,7 +19,7 @@ required:
 example:
   GrpHdr:
     MsgId: 20191113001
-    CreDtTm: 2019-11-13T10:00:00
+    CreDtTm: '2019-11-13T10:00:00'
     NbOfTxs: 1
     CtrlSum: 1000
     InitgPty:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/GenericAccountIdentification1.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/GenericAccountIdentification1.yaml
@@ -2,10 +2,22 @@ title: GenericAccountIdentification1
 type: object
 properties:
   Id:
+    description: >
+      Identification
+
+      Identification assigned by an institution.
     $ref: ./Max34Text.yaml
   SchmeNm:
+    description: >
+      SchemeName
+
+      Name of the identification scheme.
     $ref: ./AccountSchemeName1Choice.yaml
   Issr:
+    description: >
+      Issuer
+
+      Entity that assigns the identification.
     $ref: ./Max35Text.yaml
 required:
   - Id

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/GenericFinancialIdentification1.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/GenericFinancialIdentification1.yaml
@@ -2,10 +2,22 @@ title: GenericFinancialIdentification1
 type: object
 properties:
   Id:
+    description: >
+      Identification
+
+      Unique and unambiguous identification of a person.
     $ref: ./Max35Text.yaml
   SchmeNm:
+    description: >
+      SchemeName
+
+      Name of the identification scheme.
     $ref: ./FinancialIdentificationSchemeName1Choice.yaml
   Issr:
+    description: >
+      Issuer
+
+      Entity that assigns the identification.
     $ref: ./Max35Text.yaml
 required:
   - Id

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/GenericIdentification3.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/GenericIdentification3.yaml
@@ -2,8 +2,17 @@ title: GenericIdentification3
 type: object
 properties:
   Id:
+    description: >
+      Identification
+
+      Name or number assigned by an entity to enable recognition of that entity, for example,
+      account identifier.
     $ref: ./Max35Text.yaml
   Issr:
+    description: >
+      Issuer
+
+      Entity that assigns the identification.
     $ref: ./Max35Text.yaml
 required:
   - Id

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/GenericIdentification30.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/GenericIdentification30.yaml
@@ -2,10 +2,22 @@ title: GenericIdentification30
 type: object
 properties:
   Id:
+    description: >
+      Identification
+
+      Proprietary information, often a code, issued by the data source scheme issuer
     $ref: ./Exact4AlphaNumericText.yaml
   Issr:
+    description: >
+      Issuer
+
+      Entity that assigns the identification.
     $ref: ./Max35Text.yaml
   SchmeNm:
+    description: >
+      SchemeName
+
+      Short textual description of the scheme.
     $ref: ./Max35Text.yaml
 required:
   - Id

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/GenericOrganisationIdentification1.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/GenericOrganisationIdentification1.yaml
@@ -2,10 +2,22 @@ title: GenericOrganisationIdentification1
 type: object
 properties:
   Id:
+    description: >
+      Identification
+
+      Identification assigned by an institution.
     $ref: ./Max35Text.yaml
   SchmeNm:
+    description: >
+      SchemeName
+
+      Name of the identification scheme.
     $ref: ./OrganisationIdentificationSchemeName1Choice.yaml
   Issr:
+    description: >
+      Issuer
+
+      Entity that assigns the identification.
     $ref: ./Max35Text.yaml
 required:
   - Id

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/GenericOrganisationIdentification3.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/GenericOrganisationIdentification3.yaml
@@ -2,10 +2,22 @@ title: GenericOrganisationIdentification3
 type: object
 properties:
   Id:
+    description: >
+      Identification
+
+      Identification assigned by an institution.
     $ref: ./Max256Text.yaml
   SchmeNm:
+    description:
+      SchemeName
+
+      Name of the identification scheme.
     $ref: ./OrganisationIdentificationSchemeName1Choice.yaml
   Issr:
+    description: >
+      Issuer
+
+      Entity that assigns the identification.
     $ref: ./Max35Text.yaml
 required:
   - Id

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/GenericPersonIdentification1.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/GenericPersonIdentification1.yaml
@@ -2,10 +2,22 @@ title: GenericPersonIdentification1
 type: object
 properties:
   Id:
+    description: >
+      Identification
+
+      Unique and unambiguous identification of a person.
     $ref: ./Max35Text.yaml
   SchmeNm:
+    description: >
+      SchemeName
+
+      Name of the identification scheme.
     $ref: ./PersonIdentificationSchemeName1Choice.yaml
   Issr:
+    description: >
+      Issuer
+
+      Entity that assigns the identification.
     $ref: ./Max35Text.yaml
 required:
   - Id

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/GenericPersonIdentification2.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/GenericPersonIdentification2.yaml
@@ -2,10 +2,22 @@ title: GenericPersonIdentification2
 type: object
 properties:
   Id:
+    description: >
+      Identification
+
+      Unique and unambiguous identification of a person.
     $ref: ./Max256Text.yaml
   SchmeNm:
+    description: >
+      SchemeName
+
+      Name of the identification scheme.
     $ref: ./PersonIdentificationSchemeName1Choice.yaml
   Issr:
+    description: >
+      Issuer
+
+      Entity that assigns the identification.
     $ref: ./Max35Text.yaml
 required:
   - Id

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/GetPartiesError_IdentificationVerificationReportV03.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/GetPartiesError_IdentificationVerificationReportV03.yaml
@@ -2,10 +2,23 @@ title: GetPartiesError_IdentificationVerificationReportV03
 type: object
 properties:
   Assgnmt:
+    description: >
+      Assignment
+
+      Information related to the identification assignment.
     $ref: ./IdentificationAssignment3.yaml
   Rpt:
+    description: >
+      Report
+
+      Information concerning the verification of the identification data for which verification was
+      requested.
     $ref: ./VerificationReport4.yaml
   SplmtryData:
+    description: >
+      SupplementaryData
+
+      Additional information that cannot be captured in the structured elements and/or any other specific block.
     $ref: ./SupplementaryData1.yaml
 required:
   - Assgnmt

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/GetParties_IdentificationVerificationReportV03.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/GetParties_IdentificationVerificationReportV03.yaml
@@ -2,56 +2,76 @@ title: GetParties_IdentificationVerificationReportV03
 type: object
 properties:
   Assgnmt:
+    description: >
+      Assignment
+
+      Identifies the identification assignment.
     $ref: ./IdentificationAssignment3.yaml
   Rpt:
+    description: >
+      Report
+
+      Information concerning the verification of the identification data for which verification was
+      requested.
     $ref: ./VerificationReport4.yaml
   SplmtryData:
+    description: >
+      SupplementaryData
+
+      Additional information that cannot be captured in the structured elements and/or any other specific block.
     $ref: ./SupplementaryData1.yaml
 required:
   - Assgnmt
   - Rpt
 example:
   Assgnmt:
-    Id: 123
-    CreDtTm: '2013-03-07T16:30:00'
+    MsgId: 123
+    CreDtTm: '2020-01-01T00:00:00Z'
     Assgnr:
-      Id:
-        Id: 123
-        SchmeNm:
-          Cd: IBAN
-        Issr: BIC
+      OrgId:
+        Othr:
+          Id: 123
+          SchmeNm:
+            Cd: BIC
+          Issr: BIC
     Assgne:
-      Id:
-        Id: 123
-        SchmeNm:
-          Cd: IBAN
-        Issr: BIC
+      OrgId:
+        Othr:
+          Id: DFSPID
   Rpt:
-    Id: 123
-    CreDtTm: '2013-03-07T16:30:00'
-    RptgPty:
-      Id:
-        Id: 123
-        SchmeNm:
-          Cd: IBAN
-        Issr: BIC
-    RptdPty:
-      Id:
-        Id: 123
-        SchmeNm:
-          Cd: IBAN
-        Issr: BIC
-    RptdDoc:
-      Nb: 123
-      RltdDt: '2013-03-07'
-      RltdDtTp:
-        Cd: 123
-    Rsn:
-      Cd: 123
-      Prtry: 123
-  SplmtryData:
-    PlcAndNm: 123
-    Envlp: 123
-    RltdDt: '2013-03-07'
-    RltdDtTp:
-      Cd: 123
+    OrgnlId: 12345678
+    Vrfctn: true
+    UpdtdPtyAndAcctId:
+      Pty:
+        Nm: John Doe
+        PstlAdr:
+          AdrTp: ADDR
+          Dept: Dept
+          SubDept: SubDept
+          StrtNm: StrtNm
+          BldgNb: BldgNb
+          BldgNm: BldgNm
+          Flr: Flr
+          PstBx: PstBx
+          Room: Room
+          PstCd: PstCd
+          TwnNm: TwnNm
+          TwnLctnNm: TwnLctnNm
+          DstrctNm: DstrctNm
+          CtrySubDvsn: CtrySubDvsn
+          Ctry: Ctry
+          AdrLine: AdrLine
+        Id:
+          OrgId:
+            Othr:
+              Id: 18761231234
+            SchmeNm:
+              Prtry: MSISDN
+        CtryOfRes: BE
+        CtctDtls:
+          NmPrfx: Mr
+          Nm: John Doe
+          PhneNb: +123-123-321
+          MobNb: +123-123-321
+          FaxNb: +123-123-321
+          EmailAdr: example@example.com

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/GroupHeader120.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/GroupHeader120.yaml
@@ -5,10 +5,29 @@ description: >
 type: object
 properties:
   MsgId:
+    description: >
+      MessageIdentification
+
+      Definition: Point to point reference, as assigned by the instructing party, and sent to the next party in the
+      chain to unambiguously identify the message.
+
+      Usage: The instructing party has to make sure that MessageIdentification is unique per instructed party
+      for a pre-agreed period.
     $ref: ./Max35Text.yaml
   CreDtTm:
+    description: >
+      CreationDateTime
+
+      Date and time at which the message was created.
     $ref: ./ISODateTime.yaml
   TxInfAndSts:
+    description: >
+      TransactionInformationAndStatus
+
+      Definition: Agent that instructs the next party in the chain to carry out the (set of) instruction(s).
+
+      Usage: The instructing agent is the party sending the status message and not the party that sent the
+      original instruction that is being reported on.
     $ref: ./PaymentTransaction163.yaml
 required:
   - MsgId

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/IdentificationAssignment3.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/IdentificationAssignment3.yaml
@@ -4,10 +4,24 @@ properties:
   MsgId:
     $ref: ./Max35Text.yaml
   CreDtTm:
+    description: >
+      CreationDateTime
+
+      Date and time at which the identification assignment was created.
     $ref: ./ISODateTime.yaml
   Assgnr:
+    description: >
+      Assignor
+
+      Party that assigns the identification assignment to another party. This is also the sender of
+      the message.
     $ref: ./Party40Choice.yaml
   Assgne:
+    description: >
+      Assignee
+
+      Party that the identification assignment is assigned to. This is also the receiver of the
+      message.
     $ref: ./Party40Choice.yaml
 required:
   - MsgId

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/IdentificationInformation4.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/IdentificationInformation4.yaml
@@ -2,10 +2,22 @@ title: IdentificationInformation4
 type: object
 properties:
   Pty:
+    description: >
+      Party
+
+      Account owner that owes an amount of money or to whom an amount of money is due.
     $ref: ./PartyIdentification135.yaml
   Acct:
+    description: >
+      Account
+
+      Unambiguous identification of the account of a party.
     $ref: ./CashAccount40.yaml
   Agt:
+    description: >
+      Agent
+
+      Financial institution servicing an account for a party.
     $ref: ./BranchAndFinancialInstitutionIdentification6.yaml
 example:
   Pty:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/IdentificationVerificationIndicator.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/IdentificationVerificationIndicator.yaml
@@ -1,3 +1,8 @@
 title: IdentificationVerificationIndicator
 type: boolean
 example: true
+description: |
+  Definition: Identifies whether the party and/or account information received is correct.
+
+  • Meaning When True: Indicates that the identification information received is correct.
+  • Meaning When False: Indicates that the identification information received is incorrect

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/InstructionForCreditorAgent3.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/InstructionForCreditorAgent3.yaml
@@ -5,8 +5,18 @@ description: >
 type: object
 properties:
   Cd:
+    description: >
+      Code
+
+      Coded information related to the processing of the payment instruction, provided by the
+      initiating party, and intended for the creditor's agent.
     $ref: ./ExternalCreditorAgentInstruction1Code.yaml
   InstrInf:
+    description: >
+      InstructionInformation
+
+      Further information complementing the coded instruction or instruction to the creditor's agent
+      that is bilaterally agreed or specific to a user community.
     $ref: ./Max140Text.yaml
 example:
   Cd: PHOA

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/InstructionForNextAgent1.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/InstructionForNextAgent1.yaml
@@ -5,8 +5,18 @@ description: >
 type: object
 properties:
   Cd:
+    description: >
+      Code
+
+      Coded information related to the processing of the payment instruction, provided by the
+      initiating party, and intended for the next agent in the payment chain.
     $ref: ./Instruction4Code.yaml
   InstrInf:
+    description: >
+      InstructionInformation
+
+      Further information complementing the coded instruction or instruction to the next agent that
+      is bilaterally agreed or specific to a user community.
     $ref: ./Max140Text.yaml
 example:
   Cd: PHOA

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/LocalInstrument2Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/LocalInstrument2Choice.yaml
@@ -2,8 +2,16 @@ title: LocalInstrument2Choice
 type: object
 properties:
   Cd:
+    description: >
+      Code
+
+      Specifies the local instrument, as published in an external local instrument code list.
     $ref: ./ExternalLocalInstrument1Code.yaml
   Prtry:
+    description: >
+      Proprietary
+
+      Specifies the local instrument, as a proprietary code
     $ref: ./Max35Text.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/OrganisationIdentification29.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/OrganisationIdentification29.yaml
@@ -4,10 +4,22 @@ description: |
 type: object
 properties:
   AnyBIC:
+    description: >
+      AnyBIC
+
+      Business identification code of the organisation.
     $ref: ./AnyBICDec2014Identifier.yaml
   LEI:
+    description: >
+      LEI
+
+      Legal entity identification as an alternate identification for a party.
     $ref: ./LEIIdentifier.yaml
   Othr:
+    description: >
+      Other
+
+      Unique identification of an organisation, as assigned by an institution, using an identification scheme.
     $ref: ./GenericOrganisationIdentification1.yaml
 example:
   AnyBIC: BICFI

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/OrganisationIdentification39.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/OrganisationIdentification39.yaml
@@ -4,10 +4,22 @@ description: |
 type: object
 properties:
   AnyBIC:
+    description: >
+      AnyBIC
+
+      Business identification code of the organisation.
     $ref: ./AnyBICDec2014Identifier.yaml
   LEI:
+    description: >
+      LEI
+
+      Legal entity identification as an alternate identification for a party.
     $ref: ./LEIIdentifier.yaml
   Othr:
+    description: >
+      Other
+
+      Unique identification of an organisation, as assigned by an institution, using an identification scheme.
     $ref: ./GenericOrganisationIdentification3.yaml
 example:
   AnyBIC: BICFI

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/OrganisationIdentificationSchemeName1Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/OrganisationIdentificationSchemeName1Choice.yaml
@@ -4,8 +4,16 @@ description: |
 type: object
 properties:
   Cd:
+    description: >
+      Code
+
+      Name of the identification scheme, in a coded form as published in an external list.
     $ref: ./ExternalOrganisationIdentification1Code.yaml
   Prtry:
+    description: >
+      Proprietary
+
+      Name of the identification scheme, in a free text form.
     $ref: ./Max35Text.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/OtherContact1.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/OtherContact1.yaml
@@ -4,8 +4,16 @@ description: |
 type: object
 properties:
   ChanlTp:
+    description: >
+      ChannelType
+
+      Method used to contact the financial institution's contact for the specific tax region.
     $ref: ./Max4Text.yaml
   Id:
+    description: >
+      Identifier
+
+      Communication value such as phone number or email address.
     $ref: ./Max128Text.yaml
 required:
   - ChanlTp

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/PacsStatus_FIToFIPaymentStatusReportV15.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/PacsStatus_FIToFIPaymentStatusReportV15.yaml
@@ -9,71 +9,22 @@ required:
   - GrpHdr
 example:
   GrpHdr:
-    MsgId: 123
+    MsgId: 12345
     CreDtTm: '2020-01-01T00:00:00Z'
-    NbOfTxs: 1
-    SttlmInf:
-      SttlmMtd: INDA
-      SttlmDt: '2020-01-01'
-      SttlmTmIndctn: RTGS
-      SttlmTmReq: '2020-01-01T00:00:00Z'
-      SttlmAcct:
-        Id:
-          Othr:
-            Id: 123
-            SchmeNm:
-              Cd: IBAN
-            Issr: BIC
-      ClrSys:
-        Prtry: 123
-      InstgAgt:
-        FinInstnId:
-          BICFI: 123
-      InstdAgt:
-        FinInstnId:
-          BICFI: 123
-    InstgAgt:
-      FinInstnId:
-        BICFI: 123
-    InstdAgt:
-      FinInstnId:
-        BICFI: 123
-    IntrBkSttlmAmt:
-      Amt: 123
-      Ccy: EUR
-    IntrBkSttlmDt: '2020-01-01'
-    TxSts: ACCP
-    StsRsnInf:
-      Orgtr:
-        Id:
-          Othr:
-            Id: 123
-            SchmeNm:
-              Cd: IBAN
-            Issr: BIC
-      Rsn:
-        Cd: 123
-        Prtry: 123
     TxInfAndSts:
-      OrgnlInstrId: 123
-      OrgnlEndToEndId: 123
-      TxSts: ACCP
+      StsId: 12345
+      OrgnlInstrId: 12345
+      OrgnlEndToEndId: 12345
+      OrgnlTxId: 12345
+      OrgnlUETR: 123e4567-e89b-12d3-a456-426614174000
+      TxSts: RJCT
       StsRsnInf:
-        Orgtr:
-          Id:
-            Othr:
-              Id: 123
-              SchmeNm:
-                Cd: IBAN
-              Issr: BIC
-        Rsn:
-          Cd: 123
-          Prtry: 123
-      ChrgsInf:
-        Amt: 123
-        Ccy: EUR
-      IntrBkSttlmAmt:
-        Amt: 123
-        Ccy: EUR
-      IntrBkSttlmDt: '2020-01-01'
-      SttlmTmIndctn: RTGS
+        Rsn: RSN
+        AddtlInf: ADDITIONAL
+      AccptncDtTm: '2020-01-01T00:00:00Z'
+      AcctSvcrRef: ACCTSVCRREF
+      ClrSysRef: CLRSYSREF
+      ExctnConf: 1234567890ABCDEF
+      SplmtryData:
+        PlcAndNm: PLACE
+        Envlp: ENVELOPE

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/Party38Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/Party38Choice.yaml
@@ -4,8 +4,16 @@ description: |
 type: object
 properties:
   OrgId:
+    description: >
+      Organisation
+
+      Unique and unambiguous way to identify an organisation.
     $ref: ./OrganisationIdentification29.yaml
   PrvtId:
+    description: >
+      PrivateIdentification
+
+      Unique and unambiguous identification of a person, for example a passport.
     $ref: ./PersonIdentification13.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/Party40Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/Party40Choice.yaml
@@ -1,11 +1,19 @@
 title: Party40Choice
 description: |
-  Nature or use of the account.
+   Identification of a person, an organisation or a financial institution.
 type: object
 properties:
   Pty:
+    description: >
+      Party
+
+      Identification of a person or an organisation.
     $ref: ./PartyIdentification135.yaml
   Agt:
+    description: >
+      Agent
+
+      Identification of a financial institution.
     $ref: ./BranchAndFinancialInstitutionIdentification6.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/Party52Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/Party52Choice.yaml
@@ -1,11 +1,19 @@
 title: Party52Choice
 description: |
-  Nature or use of the account.
+  NOTE: Unsure on the description.
 type: object
 properties:
   OrgId:
+    description: >
+      Organisation
+
+      Unique and unambiguous way to identify an organisation.
     $ref: ./OrganisationIdentification39.yaml
   PrvtId:
+    description: >
+      Person
+
+      Unique and unambiguous identification of a person, for example a passport
     $ref: ./PersonIdentification18.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/PartyIdentification135.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/PartyIdentification135.yaml
@@ -4,26 +4,52 @@ description: |
 type: object
 properties:
   Nm:
+    description: >
+      Name by which a party is known and which is usually used to identify that party.
     $ref: ./Max140Text.yaml
   PstlAdr:
+    description: >
+      Information that locates and identifies a specific address, as defined by postal services.
     $ref: ./PostalAddress24.yaml
   Id:
+    description: >
+      Unique and unambiguous way to identify an organisation.
     $ref: ./Party38Choice.yaml
   CtryOfRes:
+    description: >
+       Country in which a person resides (the place of a person's home). In the case of a company,
+       it is the country from which the affairs of that company are directed.
     $ref: ./CountryCode.yaml
   CtctDtls:
+    description: >
+      Set of elements used to indicate how to contact the party.
     $ref: ./Contact4.yaml
 example:
   Nm: John Doe
   PstlAdr:
-    Ctry: BE
-    AdrLine:
-      - Rue du Marché 45
-      - Brussels
-      - BE
+    AdrTp: ADDR
+    Dept: Dept
+    SubDept: SubDept
+    StrtNm: StrtNm
+    BldgNb: BldgNb
+    BldgNm: BldgNm
+    Flr: Flr
+    PstBx: PstBx
+    Room: Room
+    PstCd: PstCd
+    TwnNm: TwnNm
+    TwnLctnNm: TwnLctnNm
+    DstrctNm: DstrctNm
+    CtrySubDvsn: CtrySubDvsn
+    Ctry: Ctry
+    AdrLine: AdrLine
   Id:
     OrgId:
-      AnyBIC: CCCCUS33
+      Othr:
+        Id: 123
+        SchmeNm:
+          Prtry: DfspId
+
   CtryOfRes: BE
   CtctDtls:
     NmPrfx: Mr
@@ -31,4 +57,5 @@ example:
     PhneNb: +123-123-321
     MobNb: +123-123-321
     FaxNb: +123-123-321
-    EmailAdr:
+    EmailAdr: example@example.com
+

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/PartyIdentification135.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/PartyIdentification135.yaml
@@ -5,23 +5,32 @@ type: object
 properties:
   Nm:
     description: >
+      Name
+
       Name by which a party is known and which is usually used to identify that party.
     $ref: ./Max140Text.yaml
   PstlAdr:
     description: >
+      PostalAddress
+
       Information that locates and identifies a specific address, as defined by postal services.
     $ref: ./PostalAddress24.yaml
   Id:
     description: >
+      Identification
+
       Unique and unambiguous way to identify an organisation.
     $ref: ./Party38Choice.yaml
   CtryOfRes:
     description: >
-       Country in which a person resides (the place of a person's home). In the case of a company,
-       it is the country from which the affairs of that company are directed.
+      CountryOfResidence
+      Country in which a person resides (the place of a person's home). In the case of a company,
+      it is the country from which the affairs of that company are directed.
     $ref: ./CountryCode.yaml
   CtctDtls:
     description: >
+      ContactDetails
+
       Set of elements used to indicate how to contact the party.
     $ref: ./Contact4.yaml
 example:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/PartyIdentification272.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/PartyIdentification272.yaml
@@ -4,14 +4,35 @@ description: |
 type: object
 properties:
   Nm:
+    description: >
+      Name
+
+      Name by which a party is known and which is usually used to identify that party.
     $ref: ./Max140Text.yaml
   PstlAdr:
+    description: >
+      Postal Address
+
+      Information that locates and identifies a specific address, as defined by postal services.
     $ref: ./PostalAddress27.yaml
   Id:
+    description: >
+      Identification
+
+      Unique and unambiguous identification of a party.
     $ref: ./Party52Choice.yaml
   CtryOfRes:
+    description: >
+      Country of Residence
+
+      Country in which a person resides (the place of a person's home).
+      In the case of a company, it is the country from which the affairs of that company are directed.
     $ref: ./CountryCode.yaml
   CtctDtls:
+    description: >
+      Contact Details
+
+      Set of elements used to indicate how to contact the party.
     $ref: ./Contact13.yaml
 example:
   Nm: John Doe

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/PaymentIdentification13.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/PaymentIdentification13.yaml
@@ -4,14 +4,53 @@ description: |
 type: object
 properties:
   InstrId:
+    description: >
+      InstructionIdentification
+
+      Definition: Unique identification, as assigned by an instructing party for an instructed party, to
+      unambiguously identify the instruction.
+
+      Usage: The instruction identification is a point to point reference that can be used between the
+      instructing party and the instructed party to refer to the individual instruction. It can be included in
+      several messages related to the instruction.
     $ref: ./Max35Text.yaml
   EndToEndId:
+    description: >
+      EndToEndIdentification
+
+      Definition: Unique identification, as assigned by the initiating party, to unambiguously identify the
+      transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.
+
+      Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the
+      transaction. It can be included in several messages related to the transaction.
+
+      Usage: In case there are technical limitations to pass on multiple references, the end-to-end
+      identification must be passed on throughout the entire end-to-end chain.
     $ref: ./Max35Text.yaml
   TxId:
+    description: >
+      TransactionIdentification
+
+      Definition: Unique identification, as assigned by the first instructing agent, to unambiguously identify the
+      transaction that is passed on, unchanged, throughout the entire interbank chain.
+
+      Usage: The transaction identification can be used for reconciliation, tracking or to link tasks relating to
+      the transaction on the interbank level.
+
+      Usage: The instructing agent has to make sure that the transaction identification is unique for a preagreed period.
     $ref: ./Max35Text.yaml
   UETR:
+    description: >
+      UETR
+
+      Universally unique identifier to provide an end-to-end reference of a payment transaction.
     $ref: ./UUIDv4Identifier.yaml
   ClrSysRef:
+    description: >
+      ClearingSystemReference
+
+      Unique reference, as assigned by a clearing system, to unambiguously identify the
+      instruction.
     $ref: ./Max35Text.yaml
 required:
   - EndToEndId

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/PaymentTypeInformation28.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/PaymentTypeInformation28.yaml
@@ -14,7 +14,7 @@ properties:
     description: >
       ClearingChannel
 
-      SSpecifies the clearing channel to be used to process the payment instruction.
+      Specifies the clearing channel to be used to process the payment instruction.
     $ref: ./ClearingChannel2Code.yaml
   SvcLvl:
     description: >

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/PaymentTypeInformation28.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/PaymentTypeInformation28.yaml
@@ -4,14 +4,38 @@ description: |
 type: object
 properties:
   InstrPrty:
+    description: >
+      InstructionPriority
+
+      Indicator of the urgency or order of importance that the instructing party would like the
+      instructed party to apply to the processing of the instruction.
     $ref: ./Priority2Code.yaml
   ClrChanl:
+    description: >
+      ClearingChannel
+
+      SSpecifies the clearing channel to be used to process the payment instruction.
     $ref: ./ClearingChannel2Code.yaml
   SvcLvl:
+    description: >
+      ServiceLevel
+
+      Agreement under which or rules under which the transaction should be processed.
     $ref: ./ServiceLevel8Choice.yaml
   LclInstrm:
+    description: >
+      LocalInstrument
+
+      Definition: User community specific instrument.
+
+      Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the
+      service or service level.
     $ref: ./LocalInstrument2Choice.yaml
   CtgyPurp:
+    description: >
+      CategoryPurpose
+
+      Specifies the high level purpose of the instruction based on a set of pre-defined categories.
     $ref: ./CategoryPurpose1Choice.yaml
 example:
   InstrPrty: NORM

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/PersonIdentification13.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/PersonIdentification13.yaml
@@ -4,8 +4,16 @@ description: |
 type: object
 properties:
   DtAndPlcOfBirth:
+    description: >
+      DateAndPlaceOfBirth
+
+      Date and place of birth of a person.
     $ref: ./DateAndPlaceOfBirth1.yaml
   Othr:
+    description: >
+      Other
+
+      Unique identification of a person, as assigned by an institution, using an identification scheme.
     $ref: ./GenericPersonIdentification1.yaml
 example:
   DtAndPlcOfBirth:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/PersonIdentification18.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/PersonIdentification18.yaml
@@ -4,8 +4,16 @@ description: |
 type: object
 properties:
   DtAndPlcOfBirth:
+    description: >
+      DateAndPlaceOfBirth
+
+      Date and place of birth of a person.
     $ref: ./DateAndPlaceOfBirth1.yaml
   Othr:
+    description: >
+      Other
+
+      Unique identification of a person, as assigned by an institution, using an identification scheme.
     $ref: ./GenericPersonIdentification2.yaml
 example:
   DtAndPlcOfBirth:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/PersonIdentificationSchemeName1Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/PersonIdentificationSchemeName1Choice.yaml
@@ -4,8 +4,16 @@ description: |
 type: object
 properties:
   Cd:
+    description: >
+      Code
+
+      Name of the identification scheme, in a coded form as published in an external list
     $ref: ./ExternalPersonIdentification1Code.yaml
   Prtry:
+    description: >
+      Proprietary
+
+      Name of the identification scheme, in a free text form
     $ref: ./Max35Text.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/ProxyAccountIdentification1.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/ProxyAccountIdentification1.yaml
@@ -4,8 +4,16 @@ description: |
 type: object
 properties:
   Tp:
+    description: |
+      Type
+
+      Type of the proxy identification.
     $ref: ./ProxyAccountType1Choice.yaml
   Id:
+    description: |
+      Identification
+
+      Identification used to indicate the account identification under another specified name.
     $ref: ./Max2048Text.yaml
 required:
   - Id

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/ProxyAccountType1Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/ProxyAccountType1Choice.yaml
@@ -1,11 +1,21 @@
 title: ProxyAccountType1Choice
 type: object
 description: |
-  NOTE: Unsure on description.
+  ProxyAccountType1Choice
+
+  Specifies the scheme used for the identification of an account alias.
 properties:
   Cd:
+    description: |
+      Code
+
+      Name of the identification scheme, in a coded form as published in an external list.
     $ref: ./ExternalProxyAccountType1Code.yaml
   Prtry:
+    description: |
+      Proprietary
+
+      Name of the identification scheme, in a free text form.
     $ref: ./Max35Text.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/Purpose2Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/Purpose2Choice.yaml
@@ -9,8 +9,16 @@ description: >
 type: object
 properties:
   Cd:
+    description: |
+      Code
+
+      Underlying reason for the payment transaction, as published in an external purpose code list.
     $ref: ./ExternalPurpose1Code.yaml
   Prtry:
+    description: |
+      Proprietary
+
+      Purpose, in a proprietary form.
     $ref: ./Max35Text.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/RegulatoryAuthority2.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/RegulatoryAuthority2.yaml
@@ -4,8 +4,16 @@ description: |
 type: object
 properties:
   Nm:
+    description: |
+      Name
+
+      Name of the entity requiring the regulatory reporting information.
     $ref: ./Max140Text.yaml
   Ctry:
+    description: |
+      Country
+
+      Country of the entity that requires the regulatory reporting information.
     $ref: ./CountryCode.yaml
 example:
   Nm: Swiss National Bank

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/RegulatoryReporting3.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/RegulatoryReporting3.yaml
@@ -4,11 +4,29 @@ description: |
 type: object
 properties:
   DbtCdtRptgInd:
+    description: >
+      DebitCreditReportingIndicator
+
+      Identifies whether the regulatory reporting information applies to the debit side,
+      to the credit side or to both debit and credit sides of the transaction.
     $ref: ./RegulatoryReportingType1Code.yaml
   Authrty:
+    description: |
+      Authority
+
+      Entity requiring the regulatory reporting information.
     $ref: ./RegulatoryAuthority2.yaml
   Dtls:
-    $ref: ./StructuredRegulatoryReporting3.yaml
+    description: >
+      Details
+
+      Identifies whether the regulatory reporting information applies to the debit side,
+      to the credit side or to both debit and credit sides of the transaction.
+    anyOf:
+      - $ref: ./StructuredRegulatoryReporting3.yaml
+      - items:
+          $ref: ./StructuredRegulatoryReporting3.yaml
+        type: array
 example:
   DbtCdtRptgInd: CRED
   Authrty:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/ServiceLevel8Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/ServiceLevel8Choice.yaml
@@ -4,8 +4,17 @@ description: |
 type: object
 properties:
   Cd:
+    description: >
+      Code
+
+      Specifies a pre-agreed service or level of service between the parties,
+      as published in an external service level code list.
     $ref: ./ExternalServiceLevel1Code.yaml
   Prtry:
+    description: >
+      Proprietary
+
+      Specifies a pre-agreed service or level of service between the parties, as a proprietary code.
     $ref: ./Max35Text.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/SettlementInstruction15.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/SettlementInstruction15.yaml
@@ -1,11 +1,18 @@
 title: SettlementInstruction15
 description: |
-  NOTE: Unsure on description.
+  Specifies the details on how the settlement of the original transaction(s) between the
+  instructing agent and the instructed agent was completed.
 type: object
 properties:
   SttlmMtd:
+    description: >
+      SettlementMethod
+
+      Method used to settle the (batch of) payment instructions.
     $ref: ./SettlementMethod1Code.yaml
   PmtTpInf:
+    description: |
+      PaymentTypeInformation
     $ref: ./PaymentTypeInformation28.yaml
 required:
   - SttlmMtd

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/StatusReason6Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/StatusReason6Choice.yaml
@@ -4,8 +4,16 @@ description: |
 type: object
 properties:
   Cd:
+    description: >
+      Code
+
+      Reason for the status, as published in an external reason code list.
     $ref: ./ExternalStatusReason1Code.yaml
   Prtry:
+    description: >
+      Proprietary
+
+      Reason for the status, in a proprietary form.
     $ref: ./Max35Text.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/StatusReasonInformation14.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/StatusReasonInformation14.yaml
@@ -4,10 +4,22 @@ description: |
 type: object
 properties:
   Orgtr:
+    description:
+      Originator
+
+      Party that issues the status.
     $ref: ./PartyIdentification272.yaml
   Rsn:
+    description:
+      Reason
+
+      Specifies the reason for the status report.
     $ref: ./StatusReason6Choice.yaml
   AddtlInf:
+    description:
+      AdditionalInformation
+
+      Additional information about the status report.
     $ref: ./Max105Text.yaml
 example:
   Orgtr:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/StructuredRegulatoryReporting3.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/StructuredRegulatoryReporting3.yaml
@@ -1,20 +1,50 @@
 title: StructuredRegulatoryReporting3
 description: |
-  Unsure on description.
+  StructuredRegulatoryReporting3
+
+  Information needed due to regulatory and statutory requirements.
 type: object
 properties:
   Tp:
+    description: |
+      Type
+
+      Specifies the type of the information supplied in the regulatory reporting details.
     $ref: ./Max35Text.yaml
   Dt:
+    description: |
+      Date
+
+      Date related to the specified type of regulatory reporting details.
     $ref: ./ISODate.yaml
   Ctry:
+    description: |
+      Country
+
+      Country related to the specified type of regulatory reporting details.
     $ref: ./CountryCode.yaml
   Cd:
+    description: >
+      Code
+
+      Specifies the nature, purpose, and reason for the transaction to be reported
+      for regulatory and statutory requirements in a coded form.
     $ref: ./Max10Text.yaml
   Amt:
+    description: |
+      Amount
+
+      Amount of money to be reported for regulatory and statutory requirements.
     $ref: ./ActiveOrHistoricCurrencyAndAmount.yaml
   Inf:
-    $ref: ./Max35Text.yaml
+    description: |
+      Information
+      Additional details that cater for specific domestic regulatory requirements.
+    anyOf:
+      - $ref: ./Max35Text.yaml
+      - items:
+          $ref: ./Max35Text.yaml
+        type: array
 example:
   Tp: T1
   Dt: '2018-01-01'

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/SupplementaryData1.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/SupplementaryData1.yaml
@@ -5,8 +5,20 @@ description: >
 type: object
 properties:
   PlcAndNm:
+    description: >
+      PlaceAndName
+
+      Unambiguous reference to the location where the supplementary data must be inserted in
+      the message instance.
     $ref: ./Max350Text.yaml
   Envlp:
+    description: >
+      Envelope
+
+      Technical element wrapping the supplementary data.
+
+      Technical component that contains the validated supplementary data information. This technical
+      envelope allows to segregate the supplementary data information from any other information.
     $ref: ./SupplementaryDataEnvelope1.yaml
 required:
   - Envlp

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/SupplementaryDataEnvelope1.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/SupplementaryDataEnvelope1.yaml
@@ -1,5 +1,8 @@
 title: SupplementaryDataEnvelope1
-description: |
-  Unsure on description.
+description: >
+  SupplementaryDataEnvelope1
+
+  Technical component that contains the validated supplementary data information.
+  This technical envelope allows to segregate the supplementary data information from any other information.
 type: object
 

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/TaxAmount3.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/TaxAmount3.yaml
@@ -4,13 +4,33 @@ description: |
 type: object
 properties:
   Rate:
+    description: |
+      Rate
+
+      Rate used to calculate the tax.
     $ref: ./PercentageRate.yaml
   TaxblBaseAmt:
+    description: |
+      TaxableBaseAmount
+
+      Amount of money on which the tax is based.
     $ref: ./ActiveOrHistoricCurrencyAndAmount.yaml
   TtlAmt:
+    description: |
+      TotalAmount
+
+      Total amount that is the result of the calculation of the tax for the record.
     $ref: ./ActiveOrHistoricCurrencyAndAmount.yaml
   Dtls:
-    $ref: ./TaxRecordDetails3.yaml
+    description: |
+      Details
+
+      Set of elements used to provide details on the tax period and amount.
+    anyOf:
+      - $ref: ./TaxRecordDetails3.yaml
+      - items:
+          $ref: ./TaxRecordDetails3.yaml
+        type: array
 example:
   Rate: 0.0
   TaxblBaseAmt:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/TaxAuthorisation1.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/TaxAuthorisation1.yaml
@@ -4,8 +4,16 @@ description: |
 type: object
 properties:
   Titl:
+    description: |
+      Title
+
+      Title or position of debtor or the debtor's authorised representative.
     $ref: ./Max35Text.yaml
   Nm:
+    description: |
+      Name
+
+      Name of the debtor or the debtor's authorised representative.
     $ref: ./Max140Text.yaml
 example:
   Titl: Mr

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/TaxData1.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/TaxData1.yaml
@@ -5,27 +5,75 @@ description: >
 type: object
 properties:
   Cdtr:
+    description: |
+      Creditor
+
+      Party on the credit side of the transaction to which the tax applies.
     $ref: ./TaxParty1.yaml
   Dbtr:
+    description: |
+      Debtor
+
+      Party on the debit side of the transaction to which the tax applies.
     $ref: ./TaxParty2.yaml
   UltmtDbtr:
+    description: |
+      UltimateDebtor
+
+      Ultimate party that owes an amount of money to the (ultimate) creditor, in this case, to the taxing authority.
     $ref: ./TaxParty2.yaml
   AdmstnZone:
+    description: |
+      AdministrationZone
+
+      Territorial part of a country to which the tax payment is related.
     $ref: ./Max35Text.yaml
   RefNb:
+    description: |
+      ReferenceNumber
+
+      Tax reference information that is specific to a taxing agency.
     $ref: ./Max140Text.yaml
   Mtd:
+    description: |
+      Method
+
+      Method used to indicate the underlying business or how the tax is paid.
     $ref: ./Max35Text.yaml
   TtlTaxblBaseAmt:
+    description: |
+      TotalTaxableBaseAmount
+
+      Total amount of money on which the tax is based.
     $ref: ./ActiveOrHistoricCurrencyAndAmount.yaml
   TtlTaxAmt:
+    description: |
+      TotalTaxAmount
+
+      Total amount of money as result of the calculation of the tax.
     $ref: ./ActiveOrHistoricCurrencyAndAmount.yaml
   Dt:
+    description: |
+      Date
+
+      Date by which tax is due.
     $ref: ./ISODate.yaml
   SeqNb:
+    description: |
+      SequenceNumber
+
+      Sequential number of the tax report
     $ref: ./Number.yaml
   Rcrd:
-    $ref: ./TaxRecord3.yaml
+    description: |
+      Record
+
+      Details of the tax record.
+    anyOf:
+      - $ref: ./TaxRecord3.yaml
+      - items:
+          $ref: ./TaxRecord3.yaml
+        type: array
 example:
   Cdtr:
     Titl: Mr

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/TaxParty1.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/TaxParty1.yaml
@@ -4,10 +4,22 @@ description: |
 type: object
 properties:
   TaxId:
+    description: |
+      TaxIdentification
+
+      Tax identification number of the creditor.
     $ref: ./Max35Text.yaml
   RegnId:
+    description: |
+      RegistrationIdentification
+
+      Unique identification, as assigned by an organisation, to unambiguously identify a party.
     $ref: ./Max35Text.yaml
   TaxTp:
+    description: |
+      TaxType
+
+      Type of tax payer.
     $ref: ./Max35Text.yaml
 example:
   TaxId: 123456789

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/TaxParty2.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/TaxParty2.yaml
@@ -4,12 +4,28 @@ description: |
 type: object
 properties:
   TaxId:
+    description: |
+      TaxIdentification
+
+      Tax identification number of the debtor.
     $ref: ./Max35Text.yaml
   RegnId:
+    description: |
+      RegistrationIdentification
+
+      Unique identification, as assigned by an organisation, to unambiguously identify a party.
     $ref: ./Max35Text.yaml
   TaxTp:
+    description: |
+      TaxType
+
+      Type of tax payer.
     $ref: ./Max35Text.yaml
   Authstn:
+    description: |
+      Authorisation
+
+      Details of the authorised tax paying party.
     $ref: ./TaxAuthorisation1.yaml
 example:
   TaxId: 123456789

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/TaxPeriod3.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/TaxPeriod3.yaml
@@ -3,12 +3,24 @@ description: |
   Period of time details related to the tax payment.
 type: object
 properties:
-  Yr:
-    $ref: ./ISOYear.yaml
-  Tp:
-    $ref: ./TaxRecordPeriod1Code.yaml
   FrToDt:
     $ref: ./DatePeriod2.yaml
+    description: |
+      FromToDate
+
+      Range of time between a start date and an end date for which the tax report is provided.
+  Tp:
+    $ref: ./TaxRecordPeriod1Code.yaml
+    description: |
+      Type
+
+      Identification of the period related to the tax payment.
+  Yr:
+    $ref: ./ISOYear.yaml
+    description: |
+      Year
+
+      Year related to the tax payment.
 example:
   Yr: 2020
   Tp: MM01

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/TaxRecord3.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/TaxRecord3.yaml
@@ -3,24 +3,60 @@ description: |
   Set of elements used to define the tax record.
 type: object
 properties:
-  Tp:
-    $ref: ./Max35Text.yaml
-  Ctgy:
-    $ref: ./Max35Text.yaml
-  CtgyDtls:
-    $ref: ./Max35Text.yaml
-  DbtrSts:
-    $ref: ./Max35Text.yaml
-  CertId:
-    $ref: ./Max35Text.yaml
-  FrmsCd:
-    $ref: ./Max35Text.yaml
-  Prd:
-    $ref: ./TaxPeriod3.yaml
-  TaxAmt:
-    $ref: ./TaxAmount3.yaml
   AddtlInf:
     $ref: ./Max140Text.yaml
+    description: |
+      AdditionalInformation
+
+      Further details of the tax record.
+  CertId:
+    $ref: ./Max35Text.yaml
+    description: |
+      CertificateIdentification
+
+      Identification number of the tax report as assigned by the taxing authority.
+  Ctgy:
+    $ref: ./Max35Text.yaml
+    description: |
+      Category
+
+      Specifies the tax code as published by the tax authority.
+  CtgyDtls:
+    $ref: ./Max35Text.yaml
+    description: |
+      CategoryDetails
+
+      Provides further details of the category tax code.
+  DbtrSts:
+    $ref: ./Max35Text.yaml
+    description: |
+      DebtorStatus
+
+      Code provided by local authority to identify the status of the party that has drawn up the settlement document.
+  FrmsCd:
+    $ref: ./Max35Text.yaml
+    description: |
+      FormsCode
+
+      Identifies, in a coded form, on which template the tax report is to be provided.
+  Prd:
+    $ref: ./TaxPeriod3.yaml
+    description: |
+      Period
+
+      Set of elements used to provide details on the period of time related to the tax payment.
+  TaxAmt:
+    $ref: ./TaxAmount3.yaml
+    description: |
+      TaxAmount
+
+      Set of elements used to provide information on the amount of the tax record.
+  Tp:
+    $ref: ./Max35Text.yaml
+    description: |
+      Type
+
+      High level code to identify the type of tax details.
 example:
   Tp: VAT
   Ctgy: A

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/TaxRecordDetails3.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/TaxRecordDetails3.yaml
@@ -4,8 +4,16 @@ description: |
 type: object
 properties:
   Prd:
+    description: |
+      Period
+
+      Set of elements used to provide details on the period of time related to the tax payment.
     $ref: ./TaxPeriod3.yaml
   Amt:
+    description: |
+      Amount
+
+      Underlying tax amount related to the specified period.
     $ref: ./ActiveOrHistoricCurrencyAndAmount.yaml
 required:
   - Amt

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/VerificationReason1Choice.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/VerificationReason1Choice.yaml
@@ -2,8 +2,17 @@ title: VerificationReason1Choice
 type: object
 properties:
   Cd:
+    description: >
+      Code
+
+      Reason why the verified identification information is incorrect, as published in an external
+      reason code list.
     $ref: ./ExternalVerificationReason1Code.yaml
   Prtry:
+    description: >
+      Proprietary
+
+      Reason why the verified identification information is incorrect, in a free text form.
     $ref: ./Max35Text.yaml
 oneOf:
   - required:

--- a/fspiop/v2_0_ISO20022/openapi3/components/schemas/VerificationReport4.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/components/schemas/VerificationReport4.yaml
@@ -2,28 +2,76 @@ title: VerificationReport4
 type: object
 properties:
   OrgnlId:
+    description: >
+      OriginalIdentification
+
+      Unique identification, as assigned by a sending party, to unambiguously identify the party
+      and account identification information group within the original message.
     $ref: ./Max35Text.yaml
   Vrfctn:
+    description: >
+      Verification
+
+      Identifies whether the party and/or account information received is correct.
+      Boolean value.
     $ref: ./IdentificationVerificationIndicator.yaml
   Rsn:
+    description: >
+      Reason.
+
+      Specifies the reason why the verified identification information is incorrect.
     $ref: ./VerificationReason1Choice.yaml
   OrgnlPtyAndAcctId:
+    description: >
+      OriginalPartyAndAccountIdentification
+
+      Provides party and/or account identification information as given in the original message.
     $ref: ./IdentificationInformation4.yaml
   UpdtdPtyAndAcctId:
+    description: >
+      UpdatedPartyAndAccountIdentification
+
+      Provides party and/or account identification information.
     $ref: ./IdentificationInformation4.yaml
 required:
   - OrgnlId
   - Vrfctn
 example:
-  OrgnlId: 123456789
+  OrgnlId: 1234567890123456789012345678901234
   Vrfctn: true
-  Rsn:
-    Cd: AGNT
   OrgnlPtyAndAcctId:
-    Id: 123456789
-    SchmeNm:
-      Cd: CCPT
+    Nm: John Doe
+    PstlAdr:
+      AdrTp: ADDR
+      Dept: Dept
+      SubDept: SubDept
+      StrtNm: 1234 Elm St
+      BldgNb: 1234
+      PstCd: 12345
+      TwnNm: Anytown
+      CtrySubDvsn: CA
+      Ctry: US
+    Id:
+      OrgId:
+        AnyBIC: ABCDUS33
+        Othr:
+          Id: 123456789
+          Issr: ABA
   UpdtdPtyAndAcctId:
-    Id: 123456789
-    SchmeNm:
-      Cd: CCPT
+    Nm: John Doe
+    PstlAdr:
+      AdrTp: ADDR
+      Dept: Dept
+      SubDept: SubDept
+      StrtNm: 1234 Elm St
+      BldgNb: 1234
+      PstCd: 12345
+      TwnNm: Anytown
+      CtrySubDvsn: CA
+      Ctry: US
+    Id:
+      OrgId:
+        AnyBIC: ABCDUS33
+        Othr:
+          Id: 123456789
+          Issr: ABA

--- a/fspiop/v2_0_ISO20022/openapi3/openapi.yaml
+++ b/fspiop/v2_0_ISO20022/openapi3/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.1.0
 info:
   version: v2.0-iso20022-draft
   title: Open API for FSP Interoperability (FSPIOP) - the ISO 20022 message version

--- a/package-lock.json
+++ b/package-lock.json
@@ -4972,9 +4972,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.3.tgz",
-      "integrity": "sha512-IML/R4eG/pUS5w7OfcDE0jKrljWS9nwnEfsxWCIJF5eO6AHo6+Hlv+lQbdlAYsiJPHzUthLm1RUjnBzWOs45cw==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
+      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
       "dev": true,
       "dependencies": {
         "@types/cookie": "^0.4.1",
@@ -4986,36 +4986,36 @@
         "cors": "~2.8.5",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.11.0"
+        "ws": "~8.17.1"
       },
       "engines": {
         "node": ">=10.2.0"
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.3.tgz",
-      "integrity": "sha512-9Z0qLB0NIisTRt1DZ/8U2k12RJn8yls/nXMZLn+/N8hANT3TcYjKFKcwbw5zFQiN4NTde3TSY9zb79e1ij6j9Q==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
+      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
       "dev": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.11.0",
+        "ws": "~8.17.1",
         "xmlhttprequest-ssl": "~2.0.0"
       }
     },
     "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -5036,16 +5036,16 @@
       }
     },
     "node_modules/engine.io/node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -11418,25 +11418,26 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
-      "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
       "dev": true,
       "dependencies": {
-        "ws": "~8.11.0"
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
       }
     },
     "node_modules/socket.io-adapter/node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -12917,9 +12918,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -16848,9 +16849,9 @@
       }
     },
     "engine.io": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.3.tgz",
-      "integrity": "sha512-IML/R4eG/pUS5w7OfcDE0jKrljWS9nwnEfsxWCIJF5eO6AHo6+Hlv+lQbdlAYsiJPHzUthLm1RUjnBzWOs45cw==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
+      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
       "dev": true,
       "requires": {
         "@types/cookie": "^0.4.1",
@@ -16862,35 +16863,35 @@
         "cors": "~2.8.5",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.11.0"
+        "ws": "~8.17.1"
       },
       "dependencies": {
         "ws": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+          "version": "8.17.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+          "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
           "dev": true,
           "requires": {}
         }
       }
     },
     "engine.io-client": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.3.tgz",
-      "integrity": "sha512-9Z0qLB0NIisTRt1DZ/8U2k12RJn8yls/nXMZLn+/N8hANT3TcYjKFKcwbw5zFQiN4NTde3TSY9zb79e1ij6j9Q==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
+      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
       "dev": true,
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.11.0",
+        "ws": "~8.17.1",
         "xmlhttprequest-ssl": "~2.0.0"
       },
       "dependencies": {
         "ws": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+          "version": "8.17.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+          "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
           "dev": true,
           "requires": {}
         }
@@ -21538,18 +21539,19 @@
       }
     },
     "socket.io-adapter": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
-      "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
       "dev": true,
       "requires": {
-        "ws": "~8.11.0"
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
       },
       "dependencies": {
         "ws": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+          "version": "8.17.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+          "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
           "dev": true,
           "requires": {}
         }
@@ -22628,9 +22630,9 @@
       }
     },
     "ws": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,14 +20,14 @@
         "ts-auto-mock": "^3.7.4"
       },
       "devDependencies": {
-        "@commitlint/cli": "^19.4.1",
-        "@commitlint/config-conventional": "^19.4.1",
+        "@commitlint/cli": "^19.5.0",
+        "@commitlint/config-conventional": "^19.5.0",
         "@redocly/cli": "^1.5.0",
         "@redocly/openapi-cli": "^1.0.0-beta.95",
         "@types/jest": "^29.5.12",
         "@types/js-yaml": "^4.0.9",
-        "@typescript-eslint/eslint-plugin": "^8.4.0",
-        "@typescript-eslint/parser": "^8.4.0",
+        "@typescript-eslint/eslint-plugin": "^8.5.0",
+        "@typescript-eslint/parser": "^8.5.0",
         "audit-ci": "^7.1.0",
         "browser-sync": "^3.0.2",
         "diff": "^7.0.0",
@@ -1017,17 +1017,17 @@
       "dev": true
     },
     "node_modules/@commitlint/cli": {
-      "version": "19.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.4.1.tgz",
-      "integrity": "sha512-EerFVII3ZcnhXsDT9VePyIdCJoh3jEzygN1L37MjQXgPfGS6fJTWL/KHClVMod1d8w94lFC3l4Vh/y5ysVAz2A==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.5.0.tgz",
+      "integrity": "sha512-gaGqSliGwB86MDmAAKAtV9SV1SHdmN8pnGq4EJU4+hLisQ7IFfx4jvU4s+pk6tl0+9bv6yT+CaZkufOinkSJIQ==",
       "dev": true,
       "dependencies": {
-        "@commitlint/format": "^19.3.0",
-        "@commitlint/lint": "^19.4.1",
-        "@commitlint/load": "^19.4.0",
-        "@commitlint/read": "^19.4.0",
-        "@commitlint/types": "^19.0.3",
-        "execa": "^8.0.1",
+        "@commitlint/format": "^19.5.0",
+        "@commitlint/lint": "^19.5.0",
+        "@commitlint/load": "^19.5.0",
+        "@commitlint/read": "^19.5.0",
+        "@commitlint/types": "^19.5.0",
+        "tinyexec": "^0.3.0",
         "yargs": "^17.0.0"
       },
       "bin": {
@@ -1037,147 +1037,13 @@
         "node": ">=v18"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16.17.0"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@commitlint/config-conventional": {
-      "version": "19.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.4.1.tgz",
-      "integrity": "sha512-D5S5T7ilI5roybWGc8X35OBlRXLAwuTseH1ro0XgqkOWrhZU8yOwBOslrNmSDlTXhXLq8cnfhQyC42qaUCzlXA==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.5.0.tgz",
+      "integrity": "sha512-OBhdtJyHNPryZKg0fFpZNOBM1ZDbntMvqMuSmpfyP86XSfwzGw4CaoYRG4RutUPg0BTK07VMRIkNJT6wi2zthg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^19.0.3",
+        "@commitlint/types": "^19.5.0",
         "conventional-changelog-conventionalcommits": "^7.0.2"
       },
       "engines": {
@@ -1197,12 +1063,12 @@
       }
     },
     "node_modules/@commitlint/config-validator": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.0.3.tgz",
-      "integrity": "sha512-2D3r4PKjoo59zBc2auodrSCaUnCSALCx54yveOFwwP/i2kfEAQrygwOleFWswLqK0UL/F9r07MFi5ev2ohyM4Q==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.5.0.tgz",
+      "integrity": "sha512-CHtj92H5rdhKt17RmgALhfQt95VayrUo2tSqY9g2w+laAXyk7K/Ef6uPm9tn5qSIwSmrLjKaXK9eiNuxmQrDBw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^19.0.3",
+        "@commitlint/types": "^19.5.0",
         "ajv": "^8.11.0"
       },
       "engines": {
@@ -1210,12 +1076,12 @@
       }
     },
     "node_modules/@commitlint/ensure": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.0.3.tgz",
-      "integrity": "sha512-SZEpa/VvBLoT+EFZVb91YWbmaZ/9rPH3ESrINOl0HD2kMYsjvl0tF7nMHh0EpTcv4+gTtZBAe1y/SS6/OhfZzQ==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.5.0.tgz",
+      "integrity": "sha512-Kv0pYZeMrdg48bHFEU5KKcccRfKmISSm9MvgIgkpI6m+ohFTB55qZlBW6eYqh/XDfRuIO0x4zSmvBjmOwWTwkg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^19.0.3",
+        "@commitlint/types": "^19.5.0",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.snakecase": "^4.1.1",
@@ -1227,21 +1093,21 @@
       }
     },
     "node_modules/@commitlint/execute-rule": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.0.0.tgz",
-      "integrity": "sha512-mtsdpY1qyWgAO/iOK0L6gSGeR7GFcdW7tIjcNFxcWkfLDF5qVbPHKuGATFqRMsxcO8OUKNj0+3WOHB7EHm4Jdw==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.5.0.tgz",
+      "integrity": "sha512-aqyGgytXhl2ejlk+/rfgtwpPexYyri4t8/n4ku6rRJoRhGZpLFMqrZ+YaubeGysCP6oz4mMA34YSTaSOKEeNrg==",
       "dev": true,
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.3.0.tgz",
-      "integrity": "sha512-luguk5/aF68HiF4H23ACAfk8qS8AHxl4LLN5oxPc24H+2+JRPsNr1OS3Gaea0CrH7PKhArBMKBz5RX9sA5NtTg==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.5.0.tgz",
+      "integrity": "sha512-yNy088miE52stCI3dhG/vvxFo9e4jFkU1Mj3xECfzp/bIS/JUay4491huAlVcffOoMK1cd296q0W92NlER6r3A==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^19.0.3",
+        "@commitlint/types": "^19.5.0",
         "chalk": "^5.3.0"
       },
       "engines": {
@@ -1261,12 +1127,12 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.2.2.tgz",
-      "integrity": "sha512-eNX54oXMVxncORywF4ZPFtJoBm3Tvp111tg1xf4zWXGfhBPKpfKG6R+G3G4v5CPlRROXpAOpQ3HMhA9n1Tck1g==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.5.0.tgz",
+      "integrity": "sha512-0XQ7Llsf9iL/ANtwyZ6G0NGp5Y3EQ8eDQSxv/SRcfJ0awlBY4tHFAvwWbw66FVUaWICH7iE5en+FD9TQsokZ5w==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^19.0.3",
+        "@commitlint/types": "^19.5.0",
         "semver": "^7.6.0"
       },
       "engines": {
@@ -1274,30 +1140,30 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "19.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.4.1.tgz",
-      "integrity": "sha512-Ws4YVAZ0jACTv6VThumITC1I5AG0UyXMGua3qcf55JmXIXm/ejfaVKykrqx7RyZOACKVAs8uDRIsEsi87JZ3+Q==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.5.0.tgz",
+      "integrity": "sha512-cAAQwJcRtiBxQWO0eprrAbOurtJz8U6MgYqLz+p9kLElirzSCc0vGMcyCaA1O7AqBuxo11l1XsY3FhOFowLAAg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/is-ignored": "^19.2.2",
-        "@commitlint/parse": "^19.0.3",
-        "@commitlint/rules": "^19.4.1",
-        "@commitlint/types": "^19.0.3"
+        "@commitlint/is-ignored": "^19.5.0",
+        "@commitlint/parse": "^19.5.0",
+        "@commitlint/rules": "^19.5.0",
+        "@commitlint/types": "^19.5.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "19.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.4.0.tgz",
-      "integrity": "sha512-I4lCWaEZYQJ1y+Y+gdvbGAx9pYPavqZAZ3/7/8BpWh+QjscAn8AjsUpLV2PycBsEx7gupq5gM4BViV9xwTIJuw==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.5.0.tgz",
+      "integrity": "sha512-INOUhkL/qaKqwcTUvCE8iIUf5XHsEPCLY9looJ/ipzi7jtGhgmtH7OOFiNvwYgH7mA8osUWOUDV8t4E2HAi4xA==",
       "dev": true,
       "dependencies": {
-        "@commitlint/config-validator": "^19.0.3",
-        "@commitlint/execute-rule": "^19.0.0",
-        "@commitlint/resolve-extends": "^19.1.0",
-        "@commitlint/types": "^19.0.3",
+        "@commitlint/config-validator": "^19.5.0",
+        "@commitlint/execute-rule": "^19.5.0",
+        "@commitlint/resolve-extends": "^19.5.0",
+        "@commitlint/types": "^19.5.0",
         "chalk": "^5.3.0",
         "cosmiconfig": "^9.0.0",
         "cosmiconfig-typescript-loader": "^5.0.0",
@@ -1322,21 +1188,21 @@
       }
     },
     "node_modules/@commitlint/message": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.0.0.tgz",
-      "integrity": "sha512-c9czf6lU+9oF9gVVa2lmKaOARJvt4soRsVmbR7Njwp9FpbBgste5i7l/2l5o8MmbwGh4yE1snfnsy2qyA2r/Fw==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.5.0.tgz",
+      "integrity": "sha512-R7AM4YnbxN1Joj1tMfCyBryOC5aNJBdxadTZkuqtWi3Xj0kMdutq16XQwuoGbIzL2Pk62TALV1fZDCv36+JhTQ==",
       "dev": true,
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.0.3.tgz",
-      "integrity": "sha512-Il+tNyOb8VDxN3P6XoBBwWJtKKGzHlitEuXA5BP6ir/3loWlsSqDr5aecl6hZcC/spjq4pHqNh0qPlfeWu38QA==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.5.0.tgz",
+      "integrity": "sha512-cZ/IxfAlfWYhAQV0TwcbdR1Oc0/r0Ik1GEessDJ3Lbuma/MRO8FRQX76eurcXtmhJC//rj52ZSZuXUg0oIX0Fw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^19.0.3",
+        "@commitlint/types": "^19.5.0",
         "conventional-changelog-angular": "^7.0.0",
         "conventional-commits-parser": "^5.0.0"
       },
@@ -1420,16 +1286,16 @@
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "19.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.4.0.tgz",
-      "integrity": "sha512-r95jLOEZzKDakXtnQub+zR3xjdnrl2XzerPwm7ch1/cc5JGq04tyaNpa6ty0CRCWdVrk4CZHhqHozb8yZwy2+g==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.5.0.tgz",
+      "integrity": "sha512-TjS3HLPsLsxFPQj6jou8/CZFAmOP2y+6V4PGYt3ihbQKTY1Jnv0QG28WRKl/d1ha6zLODPZqsxLEov52dhR9BQ==",
       "dev": true,
       "dependencies": {
-        "@commitlint/top-level": "^19.0.0",
-        "@commitlint/types": "^19.0.3",
-        "execa": "^8.0.1",
+        "@commitlint/top-level": "^19.5.0",
+        "@commitlint/types": "^19.5.0",
         "git-raw-commits": "^4.0.0",
-        "minimist": "^1.2.8"
+        "minimist": "^1.2.8",
+        "tinyexec": "^0.3.0"
       },
       "engines": {
         "node": ">=v18"
@@ -1442,41 +1308,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/read/node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@commitlint/read/node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1499,27 +1330,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/@commitlint/read/node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16.17.0"
-      }
-    },
-    "node_modules/@commitlint/read/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@commitlint/read/node_modules/meow": {
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
@@ -1532,72 +1342,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@commitlint/read/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/read/node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/read/node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/read/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/read/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@commitlint/read/node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -1607,26 +1351,14 @@
         "node": ">= 10.x"
       }
     },
-    "node_modules/@commitlint/read/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.1.0.tgz",
-      "integrity": "sha512-z2riI+8G3CET5CPgXJPlzftH+RiWYLMYv4C9tSLdLXdr6pBNimSKukYP9MS27ejmscqCTVA4almdLh0ODD2KYg==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.5.0.tgz",
+      "integrity": "sha512-CU/GscZhCUsJwcKTJS9Ndh3AKGZTNFIOoQB2n8CmFnizE0VnEuJoum+COW+C1lNABEeqk6ssfc1Kkalm4bDklA==",
       "dev": true,
       "dependencies": {
-        "@commitlint/config-validator": "^19.0.3",
-        "@commitlint/types": "^19.0.3",
+        "@commitlint/config-validator": "^19.5.0",
+        "@commitlint/types": "^19.5.0",
         "global-directory": "^4.0.1",
         "import-meta-resolve": "^4.0.0",
         "lodash.mergewith": "^4.6.2",
@@ -1637,168 +1369,33 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "19.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.4.1.tgz",
-      "integrity": "sha512-AgctfzAONoVxmxOXRyxXIq7xEPrd7lK/60h2egp9bgGUMZK9v0+YqLOA+TH+KqCa63ZoCr8owP2YxoSSu7IgnQ==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.5.0.tgz",
+      "integrity": "sha512-hDW5TPyf/h1/EufSHEKSp6Hs+YVsDMHazfJ2azIk9tHPXS6UqSz1dIRs1gpqS3eMXgtkT7JH6TW4IShdqOwhAw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/ensure": "^19.0.3",
-        "@commitlint/message": "^19.0.0",
-        "@commitlint/to-lines": "^19.0.0",
-        "@commitlint/types": "^19.0.3",
-        "execa": "^8.0.1"
+        "@commitlint/ensure": "^19.5.0",
+        "@commitlint/message": "^19.5.0",
+        "@commitlint/to-lines": "^19.5.0",
+        "@commitlint/types": "^19.5.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
-    "node_modules/@commitlint/rules/node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@commitlint/rules/node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/rules/node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16.17.0"
-      }
-    },
-    "node_modules/@commitlint/rules/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/rules/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/rules/node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/rules/node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/rules/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/rules/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@commitlint/rules/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@commitlint/to-lines": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.0.0.tgz",
-      "integrity": "sha512-vkxWo+VQU5wFhiP9Ub9Sre0FYe019JxFikrALVoD5UGa8/t3yOJEpEhxC5xKiENKKhUkTpEItMTRAjHw2SCpZw==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.5.0.tgz",
+      "integrity": "sha512-R772oj3NHPkodOSRZ9bBVNq224DOxQtNef5Pl8l2M8ZnkkzQfeSTr4uxawV2Sd3ui05dUVzvLNnzenDBO1KBeQ==",
       "dev": true,
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/top-level": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.0.0.tgz",
-      "integrity": "sha512-KKjShd6u1aMGNkCkaX4aG1jOGdn7f8ZI8TR1VEuNqUOjWTOdcDSsmglinglJ18JTjuBX5I1PtjrhQCRcixRVFQ==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.5.0.tgz",
+      "integrity": "sha512-IP1YLmGAk0yWrImPRRc578I3dDUI5A2UBJx9FbSOjxe9sTlzFiwVJ+zeMLgAtHMtGZsC8LUnzmW1qRemkFU4ng==",
       "dev": true,
       "dependencies": {
         "find-up": "^7.0.0"
@@ -1891,9 +1488,9 @@
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.0.3.tgz",
-      "integrity": "sha512-tpyc+7i6bPG9mvaBbtKUeghfyZSDgWquIDfMgqYtTbmZ9Y9VzEm2je9EYcQ0aoz5o7NvGS+rcDec93yO08MHYA==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.5.0.tgz",
+      "integrity": "sha512-DSHae2obMSMkAtTBSOulg5X7/z+rGLxcXQIkg3OmWvY6wifojge5uVMydfhUvs7yQj+V7jNmRZ2Xzl8GJyqRgg==",
       "dev": true,
       "dependencies": {
         "@types/conventional-commits-parser": "^5.0.0",
@@ -3082,16 +2679,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.4.0.tgz",
-      "integrity": "sha512-rg8LGdv7ri3oAlenMACk9e+AR4wUV0yrrG+XKsGKOK0EVgeEDqurkXMPILG2836fW4ibokTB5v4b6Z9+GYQDEw==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.5.0.tgz",
+      "integrity": "sha512-lHS5hvz33iUFQKuPFGheAB84LwcJ60G8vKnEhnfcK1l8kGVLro2SFYW6K0/tj8FUhRJ0VHyg1oAfg50QGbPPHw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.4.0",
-        "@typescript-eslint/type-utils": "8.4.0",
-        "@typescript-eslint/utils": "8.4.0",
-        "@typescript-eslint/visitor-keys": "8.4.0",
+        "@typescript-eslint/scope-manager": "8.5.0",
+        "@typescript-eslint/type-utils": "8.5.0",
+        "@typescript-eslint/utils": "8.5.0",
+        "@typescript-eslint/visitor-keys": "8.5.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -3115,15 +2712,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.4.0.tgz",
-      "integrity": "sha512-NHgWmKSgJk5K9N16GIhQ4jSobBoJwrmURaLErad0qlLjrpP5bECYg+wxVTGlGZmJbU03jj/dfnb6V9bw+5icsA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.5.0.tgz",
+      "integrity": "sha512-gF77eNv0Xz2UJg/NbpWJ0kqAm35UMsvZf1GHj8D9MRFTj/V3tAciIWXfmPLsAAF/vUlpWPvUDyH1jjsr0cMVWw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.4.0",
-        "@typescript-eslint/types": "8.4.0",
-        "@typescript-eslint/typescript-estree": "8.4.0",
-        "@typescript-eslint/visitor-keys": "8.4.0",
+        "@typescript-eslint/scope-manager": "8.5.0",
+        "@typescript-eslint/types": "8.5.0",
+        "@typescript-eslint/typescript-estree": "8.5.0",
+        "@typescript-eslint/visitor-keys": "8.5.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3143,13 +2740,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.4.0.tgz",
-      "integrity": "sha512-n2jFxLeY0JmKfUqy3P70rs6vdoPjHK8P/w+zJcV3fk0b0BwRXC/zxRTEnAsgYT7MwdQDt/ZEbtdzdVC+hcpF0A==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.5.0.tgz",
+      "integrity": "sha512-06JOQ9Qgj33yvBEx6tpC8ecP9o860rsR22hWMEd12WcTRrfaFgHr2RB/CA/B+7BMhHkXT4chg2MyboGdFGawYg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.4.0",
-        "@typescript-eslint/visitor-keys": "8.4.0"
+        "@typescript-eslint/types": "8.5.0",
+        "@typescript-eslint/visitor-keys": "8.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3160,13 +2757,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.4.0.tgz",
-      "integrity": "sha512-pu2PAmNrl9KX6TtirVOrbLPLwDmASpZhK/XU7WvoKoCUkdtq9zF7qQ7gna0GBZFN0hci0vHaSusiL2WpsQk37A==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.5.0.tgz",
+      "integrity": "sha512-N1K8Ix+lUM+cIDhL2uekVn/ZD7TZW+9/rwz8DclQpcQ9rk4sIL5CAlBC0CugWKREmDjBzI/kQqU4wkg46jWLYA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.4.0",
-        "@typescript-eslint/utils": "8.4.0",
+        "@typescript-eslint/typescript-estree": "8.5.0",
+        "@typescript-eslint/utils": "8.5.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -3184,9 +2781,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.4.0.tgz",
-      "integrity": "sha512-T1RB3KQdskh9t3v/qv7niK6P8yvn7ja1mS7QK7XfRVL6wtZ8/mFs/FHf4fKvTA0rKnqnYxl/uHFNbnEt0phgbw==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.5.0.tgz",
+      "integrity": "sha512-qjkormnQS5wF9pjSi6q60bKUHH44j2APxfh9TQRXK8wbYVeDYYdYJGIROL87LGZZ2gz3Rbmjc736qyL8deVtdw==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3197,13 +2794,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.4.0.tgz",
-      "integrity": "sha512-kJ2OIP4dQw5gdI4uXsaxUZHRwWAGpREJ9Zq6D5L0BweyOrWsL6Sz0YcAZGWhvKnH7fm1J5YFE1JrQL0c9dd53A==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.5.0.tgz",
+      "integrity": "sha512-vEG2Sf9P8BPQ+d0pxdfndw3xIXaoSjliG0/Ejk7UggByZPKXmJmw3GW5jV2gHNQNawBUyfahoSiCFVov0Ruf7Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.4.0",
-        "@typescript-eslint/visitor-keys": "8.4.0",
+        "@typescript-eslint/types": "8.5.0",
+        "@typescript-eslint/visitor-keys": "8.5.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -3249,15 +2846,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.4.0.tgz",
-      "integrity": "sha512-swULW8n1IKLjRAgciCkTCafyTHHfwVQFt8DovmaF69sKbOxTSFMmIZaSHjqO9i/RV0wIblaawhzvtva8Nmm7lQ==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.5.0.tgz",
+      "integrity": "sha512-6yyGYVL0e+VzGYp60wvkBHiqDWOpT63pdMV2CVG4LVDd5uR6q1qQN/7LafBZtAtNIn/mqXjsSeS5ggv/P0iECw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.4.0",
-        "@typescript-eslint/types": "8.4.0",
-        "@typescript-eslint/typescript-estree": "8.4.0"
+        "@typescript-eslint/scope-manager": "8.5.0",
+        "@typescript-eslint/types": "8.5.0",
+        "@typescript-eslint/typescript-estree": "8.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3271,12 +2868,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.4.0.tgz",
-      "integrity": "sha512-zTQD6WLNTre1hj5wp09nBIDiOc2U5r/qmzo7wxPn4ZgAjHql09EofqhF9WF+fZHzL5aCyaIpPcT2hyxl73kr9A==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.5.0.tgz",
+      "integrity": "sha512-yTPqMnbAZJNy2Xq2XU8AdtOW9tJIr+UQb64aXB9f3B1498Zx9JorVgFJcZpEc9UBuCCrdzKID2RGAMkYcDtZOw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.4.0",
+        "@typescript-eslint/types": "8.5.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -12622,6 +12219,12 @@
         "readable-stream": "3"
       }
     },
+    "node_modules/tinyexec": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.0.tgz",
+      "integrity": "sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==",
+      "dev": true
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -14222,106 +13825,27 @@
       "dev": true
     },
     "@commitlint/cli": {
-      "version": "19.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.4.1.tgz",
-      "integrity": "sha512-EerFVII3ZcnhXsDT9VePyIdCJoh3jEzygN1L37MjQXgPfGS6fJTWL/KHClVMod1d8w94lFC3l4Vh/y5ysVAz2A==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.5.0.tgz",
+      "integrity": "sha512-gaGqSliGwB86MDmAAKAtV9SV1SHdmN8pnGq4EJU4+hLisQ7IFfx4jvU4s+pk6tl0+9bv6yT+CaZkufOinkSJIQ==",
       "dev": true,
       "requires": {
-        "@commitlint/format": "^19.3.0",
-        "@commitlint/lint": "^19.4.1",
-        "@commitlint/load": "^19.4.0",
-        "@commitlint/read": "^19.4.0",
-        "@commitlint/types": "^19.0.3",
-        "execa": "^8.0.1",
+        "@commitlint/format": "^19.5.0",
+        "@commitlint/lint": "^19.5.0",
+        "@commitlint/load": "^19.5.0",
+        "@commitlint/read": "^19.5.0",
+        "@commitlint/types": "^19.5.0",
+        "tinyexec": "^0.3.0",
         "yargs": "^17.0.0"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-          "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.3",
-            "get-stream": "^8.0.1",
-            "human-signals": "^5.0.0",
-            "is-stream": "^3.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^5.1.0",
-            "onetime": "^6.0.0",
-            "signal-exit": "^4.1.0",
-            "strip-final-newline": "^3.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-          "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-          "dev": true
-        },
-        "human-signals": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-          "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-          "dev": true
-        },
-        "is-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-          "dev": true
-        },
-        "mimic-fn": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-          "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-          "dev": true,
-          "requires": {
-            "path-key": "^4.0.0"
-          }
-        },
-        "onetime": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^4.0.0"
-          }
-        },
-        "path-key": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-          "dev": true
-        },
-        "strip-final-newline": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-          "dev": true
-        }
       }
     },
     "@commitlint/config-conventional": {
-      "version": "19.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.4.1.tgz",
-      "integrity": "sha512-D5S5T7ilI5roybWGc8X35OBlRXLAwuTseH1ro0XgqkOWrhZU8yOwBOslrNmSDlTXhXLq8cnfhQyC42qaUCzlXA==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.5.0.tgz",
+      "integrity": "sha512-OBhdtJyHNPryZKg0fFpZNOBM1ZDbntMvqMuSmpfyP86XSfwzGw4CaoYRG4RutUPg0BTK07VMRIkNJT6wi2zthg==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^19.0.3",
+        "@commitlint/types": "^19.5.0",
         "conventional-changelog-conventionalcommits": "^7.0.2"
       },
       "dependencies": {
@@ -14337,22 +13861,22 @@
       }
     },
     "@commitlint/config-validator": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.0.3.tgz",
-      "integrity": "sha512-2D3r4PKjoo59zBc2auodrSCaUnCSALCx54yveOFwwP/i2kfEAQrygwOleFWswLqK0UL/F9r07MFi5ev2ohyM4Q==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.5.0.tgz",
+      "integrity": "sha512-CHtj92H5rdhKt17RmgALhfQt95VayrUo2tSqY9g2w+laAXyk7K/Ef6uPm9tn5qSIwSmrLjKaXK9eiNuxmQrDBw==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^19.0.3",
+        "@commitlint/types": "^19.5.0",
         "ajv": "^8.11.0"
       }
     },
     "@commitlint/ensure": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.0.3.tgz",
-      "integrity": "sha512-SZEpa/VvBLoT+EFZVb91YWbmaZ/9rPH3ESrINOl0HD2kMYsjvl0tF7nMHh0EpTcv4+gTtZBAe1y/SS6/OhfZzQ==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.5.0.tgz",
+      "integrity": "sha512-Kv0pYZeMrdg48bHFEU5KKcccRfKmISSm9MvgIgkpI6m+ohFTB55qZlBW6eYqh/XDfRuIO0x4zSmvBjmOwWTwkg==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^19.0.3",
+        "@commitlint/types": "^19.5.0",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.snakecase": "^4.1.1",
@@ -14361,18 +13885,18 @@
       }
     },
     "@commitlint/execute-rule": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.0.0.tgz",
-      "integrity": "sha512-mtsdpY1qyWgAO/iOK0L6gSGeR7GFcdW7tIjcNFxcWkfLDF5qVbPHKuGATFqRMsxcO8OUKNj0+3WOHB7EHm4Jdw==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.5.0.tgz",
+      "integrity": "sha512-aqyGgytXhl2ejlk+/rfgtwpPexYyri4t8/n4ku6rRJoRhGZpLFMqrZ+YaubeGysCP6oz4mMA34YSTaSOKEeNrg==",
       "dev": true
     },
     "@commitlint/format": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.3.0.tgz",
-      "integrity": "sha512-luguk5/aF68HiF4H23ACAfk8qS8AHxl4LLN5oxPc24H+2+JRPsNr1OS3Gaea0CrH7PKhArBMKBz5RX9sA5NtTg==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.5.0.tgz",
+      "integrity": "sha512-yNy088miE52stCI3dhG/vvxFo9e4jFkU1Mj3xECfzp/bIS/JUay4491huAlVcffOoMK1cd296q0W92NlER6r3A==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^19.0.3",
+        "@commitlint/types": "^19.5.0",
         "chalk": "^5.3.0"
       },
       "dependencies": {
@@ -14385,37 +13909,37 @@
       }
     },
     "@commitlint/is-ignored": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.2.2.tgz",
-      "integrity": "sha512-eNX54oXMVxncORywF4ZPFtJoBm3Tvp111tg1xf4zWXGfhBPKpfKG6R+G3G4v5CPlRROXpAOpQ3HMhA9n1Tck1g==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.5.0.tgz",
+      "integrity": "sha512-0XQ7Llsf9iL/ANtwyZ6G0NGp5Y3EQ8eDQSxv/SRcfJ0awlBY4tHFAvwWbw66FVUaWICH7iE5en+FD9TQsokZ5w==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^19.0.3",
+        "@commitlint/types": "^19.5.0",
         "semver": "^7.6.0"
       }
     },
     "@commitlint/lint": {
-      "version": "19.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.4.1.tgz",
-      "integrity": "sha512-Ws4YVAZ0jACTv6VThumITC1I5AG0UyXMGua3qcf55JmXIXm/ejfaVKykrqx7RyZOACKVAs8uDRIsEsi87JZ3+Q==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.5.0.tgz",
+      "integrity": "sha512-cAAQwJcRtiBxQWO0eprrAbOurtJz8U6MgYqLz+p9kLElirzSCc0vGMcyCaA1O7AqBuxo11l1XsY3FhOFowLAAg==",
       "dev": true,
       "requires": {
-        "@commitlint/is-ignored": "^19.2.2",
-        "@commitlint/parse": "^19.0.3",
-        "@commitlint/rules": "^19.4.1",
-        "@commitlint/types": "^19.0.3"
+        "@commitlint/is-ignored": "^19.5.0",
+        "@commitlint/parse": "^19.5.0",
+        "@commitlint/rules": "^19.5.0",
+        "@commitlint/types": "^19.5.0"
       }
     },
     "@commitlint/load": {
-      "version": "19.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.4.0.tgz",
-      "integrity": "sha512-I4lCWaEZYQJ1y+Y+gdvbGAx9pYPavqZAZ3/7/8BpWh+QjscAn8AjsUpLV2PycBsEx7gupq5gM4BViV9xwTIJuw==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.5.0.tgz",
+      "integrity": "sha512-INOUhkL/qaKqwcTUvCE8iIUf5XHsEPCLY9looJ/ipzi7jtGhgmtH7OOFiNvwYgH7mA8osUWOUDV8t4E2HAi4xA==",
       "dev": true,
       "requires": {
-        "@commitlint/config-validator": "^19.0.3",
-        "@commitlint/execute-rule": "^19.0.0",
-        "@commitlint/resolve-extends": "^19.1.0",
-        "@commitlint/types": "^19.0.3",
+        "@commitlint/config-validator": "^19.5.0",
+        "@commitlint/execute-rule": "^19.5.0",
+        "@commitlint/resolve-extends": "^19.5.0",
+        "@commitlint/types": "^19.5.0",
         "chalk": "^5.3.0",
         "cosmiconfig": "^9.0.0",
         "cosmiconfig-typescript-loader": "^5.0.0",
@@ -14433,18 +13957,18 @@
       }
     },
     "@commitlint/message": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.0.0.tgz",
-      "integrity": "sha512-c9czf6lU+9oF9gVVa2lmKaOARJvt4soRsVmbR7Njwp9FpbBgste5i7l/2l5o8MmbwGh4yE1snfnsy2qyA2r/Fw==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.5.0.tgz",
+      "integrity": "sha512-R7AM4YnbxN1Joj1tMfCyBryOC5aNJBdxadTZkuqtWi3Xj0kMdutq16XQwuoGbIzL2Pk62TALV1fZDCv36+JhTQ==",
       "dev": true
     },
     "@commitlint/parse": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.0.3.tgz",
-      "integrity": "sha512-Il+tNyOb8VDxN3P6XoBBwWJtKKGzHlitEuXA5BP6ir/3loWlsSqDr5aecl6hZcC/spjq4pHqNh0qPlfeWu38QA==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.5.0.tgz",
+      "integrity": "sha512-cZ/IxfAlfWYhAQV0TwcbdR1Oc0/r0Ik1GEessDJ3Lbuma/MRO8FRQX76eurcXtmhJC//rj52ZSZuXUg0oIX0Fw==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^19.0.3",
+        "@commitlint/types": "^19.5.0",
         "conventional-changelog-angular": "^7.0.0",
         "conventional-commits-parser": "^5.0.0"
       },
@@ -14500,45 +14024,22 @@
       }
     },
     "@commitlint/read": {
-      "version": "19.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.4.0.tgz",
-      "integrity": "sha512-r95jLOEZzKDakXtnQub+zR3xjdnrl2XzerPwm7ch1/cc5JGq04tyaNpa6ty0CRCWdVrk4CZHhqHozb8yZwy2+g==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.5.0.tgz",
+      "integrity": "sha512-TjS3HLPsLsxFPQj6jou8/CZFAmOP2y+6V4PGYt3ihbQKTY1Jnv0QG28WRKl/d1ha6zLODPZqsxLEov52dhR9BQ==",
       "dev": true,
       "requires": {
-        "@commitlint/top-level": "^19.0.0",
-        "@commitlint/types": "^19.0.3",
-        "execa": "^8.0.1",
+        "@commitlint/top-level": "^19.5.0",
+        "@commitlint/types": "^19.5.0",
         "git-raw-commits": "^4.0.0",
-        "minimist": "^1.2.8"
+        "minimist": "^1.2.8",
+        "tinyexec": "^0.3.0"
       },
       "dependencies": {
         "dargs": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
           "integrity": "sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==",
-          "dev": true
-        },
-        "execa": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-          "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.3",
-            "get-stream": "^8.0.1",
-            "human-signals": "^5.0.0",
-            "is-stream": "^3.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^5.1.0",
-            "onetime": "^6.0.0",
-            "signal-exit": "^4.1.0",
-            "strip-final-newline": "^3.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-          "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
           "dev": true
         },
         "git-raw-commits": {
@@ -14552,58 +14053,10 @@
             "split2": "^4.0.0"
           }
         },
-        "human-signals": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-          "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-          "dev": true
-        },
-        "is-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-          "dev": true
-        },
         "meow": {
           "version": "12.1.1",
           "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
           "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
-          "dev": true
-        },
-        "mimic-fn": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-          "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-          "dev": true,
-          "requires": {
-            "path-key": "^4.0.0"
-          }
-        },
-        "onetime": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^4.0.0"
-          }
-        },
-        "path-key": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
           "dev": true
         },
         "split2": {
@@ -14611,23 +14064,17 @@
           "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
           "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
           "dev": true
-        },
-        "strip-final-newline": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-          "dev": true
         }
       }
     },
     "@commitlint/resolve-extends": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.1.0.tgz",
-      "integrity": "sha512-z2riI+8G3CET5CPgXJPlzftH+RiWYLMYv4C9tSLdLXdr6pBNimSKukYP9MS27ejmscqCTVA4almdLh0ODD2KYg==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.5.0.tgz",
+      "integrity": "sha512-CU/GscZhCUsJwcKTJS9Ndh3AKGZTNFIOoQB2n8CmFnizE0VnEuJoum+COW+C1lNABEeqk6ssfc1Kkalm4bDklA==",
       "dev": true,
       "requires": {
-        "@commitlint/config-validator": "^19.0.3",
-        "@commitlint/types": "^19.0.3",
+        "@commitlint/config-validator": "^19.5.0",
+        "@commitlint/types": "^19.5.0",
         "global-directory": "^4.0.1",
         "import-meta-resolve": "^4.0.0",
         "lodash.mergewith": "^4.6.2",
@@ -14635,107 +14082,27 @@
       }
     },
     "@commitlint/rules": {
-      "version": "19.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.4.1.tgz",
-      "integrity": "sha512-AgctfzAONoVxmxOXRyxXIq7xEPrd7lK/60h2egp9bgGUMZK9v0+YqLOA+TH+KqCa63ZoCr8owP2YxoSSu7IgnQ==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.5.0.tgz",
+      "integrity": "sha512-hDW5TPyf/h1/EufSHEKSp6Hs+YVsDMHazfJ2azIk9tHPXS6UqSz1dIRs1gpqS3eMXgtkT7JH6TW4IShdqOwhAw==",
       "dev": true,
       "requires": {
-        "@commitlint/ensure": "^19.0.3",
-        "@commitlint/message": "^19.0.0",
-        "@commitlint/to-lines": "^19.0.0",
-        "@commitlint/types": "^19.0.3",
-        "execa": "^8.0.1"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-          "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.3",
-            "get-stream": "^8.0.1",
-            "human-signals": "^5.0.0",
-            "is-stream": "^3.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^5.1.0",
-            "onetime": "^6.0.0",
-            "signal-exit": "^4.1.0",
-            "strip-final-newline": "^3.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-          "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-          "dev": true
-        },
-        "human-signals": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-          "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-          "dev": true
-        },
-        "is-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-          "dev": true
-        },
-        "mimic-fn": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-          "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-          "dev": true,
-          "requires": {
-            "path-key": "^4.0.0"
-          }
-        },
-        "onetime": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^4.0.0"
-          }
-        },
-        "path-key": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-          "dev": true
-        },
-        "strip-final-newline": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-          "dev": true
-        }
+        "@commitlint/ensure": "^19.5.0",
+        "@commitlint/message": "^19.5.0",
+        "@commitlint/to-lines": "^19.5.0",
+        "@commitlint/types": "^19.5.0"
       }
     },
     "@commitlint/to-lines": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.0.0.tgz",
-      "integrity": "sha512-vkxWo+VQU5wFhiP9Ub9Sre0FYe019JxFikrALVoD5UGa8/t3yOJEpEhxC5xKiENKKhUkTpEItMTRAjHw2SCpZw==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.5.0.tgz",
+      "integrity": "sha512-R772oj3NHPkodOSRZ9bBVNq224DOxQtNef5Pl8l2M8ZnkkzQfeSTr4uxawV2Sd3ui05dUVzvLNnzenDBO1KBeQ==",
       "dev": true
     },
     "@commitlint/top-level": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.0.0.tgz",
-      "integrity": "sha512-KKjShd6u1aMGNkCkaX4aG1jOGdn7f8ZI8TR1VEuNqUOjWTOdcDSsmglinglJ18JTjuBX5I1PtjrhQCRcixRVFQ==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.5.0.tgz",
+      "integrity": "sha512-IP1YLmGAk0yWrImPRRc578I3dDUI5A2UBJx9FbSOjxe9sTlzFiwVJ+zeMLgAtHMtGZsC8LUnzmW1qRemkFU4ng==",
       "dev": true,
       "requires": {
         "find-up": "^7.0.0"
@@ -14794,9 +14161,9 @@
       }
     },
     "@commitlint/types": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.0.3.tgz",
-      "integrity": "sha512-tpyc+7i6bPG9mvaBbtKUeghfyZSDgWquIDfMgqYtTbmZ9Y9VzEm2je9EYcQ0aoz5o7NvGS+rcDec93yO08MHYA==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.5.0.tgz",
+      "integrity": "sha512-DSHae2obMSMkAtTBSOulg5X7/z+rGLxcXQIkg3OmWvY6wifojge5uVMydfhUvs7yQj+V7jNmRZ2Xzl8GJyqRgg==",
       "dev": true,
       "requires": {
         "@types/conventional-commits-parser": "^5.0.0",
@@ -15797,16 +15164,16 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.4.0.tgz",
-      "integrity": "sha512-rg8LGdv7ri3oAlenMACk9e+AR4wUV0yrrG+XKsGKOK0EVgeEDqurkXMPILG2836fW4ibokTB5v4b6Z9+GYQDEw==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.5.0.tgz",
+      "integrity": "sha512-lHS5hvz33iUFQKuPFGheAB84LwcJ60G8vKnEhnfcK1l8kGVLro2SFYW6K0/tj8FUhRJ0VHyg1oAfg50QGbPPHw==",
       "dev": true,
       "requires": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.4.0",
-        "@typescript-eslint/type-utils": "8.4.0",
-        "@typescript-eslint/utils": "8.4.0",
-        "@typescript-eslint/visitor-keys": "8.4.0",
+        "@typescript-eslint/scope-manager": "8.5.0",
+        "@typescript-eslint/type-utils": "8.5.0",
+        "@typescript-eslint/utils": "8.5.0",
+        "@typescript-eslint/visitor-keys": "8.5.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -15814,54 +15181,54 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.4.0.tgz",
-      "integrity": "sha512-NHgWmKSgJk5K9N16GIhQ4jSobBoJwrmURaLErad0qlLjrpP5bECYg+wxVTGlGZmJbU03jj/dfnb6V9bw+5icsA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.5.0.tgz",
+      "integrity": "sha512-gF77eNv0Xz2UJg/NbpWJ0kqAm35UMsvZf1GHj8D9MRFTj/V3tAciIWXfmPLsAAF/vUlpWPvUDyH1jjsr0cMVWw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "8.4.0",
-        "@typescript-eslint/types": "8.4.0",
-        "@typescript-eslint/typescript-estree": "8.4.0",
-        "@typescript-eslint/visitor-keys": "8.4.0",
+        "@typescript-eslint/scope-manager": "8.5.0",
+        "@typescript-eslint/types": "8.5.0",
+        "@typescript-eslint/typescript-estree": "8.5.0",
+        "@typescript-eslint/visitor-keys": "8.5.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.4.0.tgz",
-      "integrity": "sha512-n2jFxLeY0JmKfUqy3P70rs6vdoPjHK8P/w+zJcV3fk0b0BwRXC/zxRTEnAsgYT7MwdQDt/ZEbtdzdVC+hcpF0A==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.5.0.tgz",
+      "integrity": "sha512-06JOQ9Qgj33yvBEx6tpC8ecP9o860rsR22hWMEd12WcTRrfaFgHr2RB/CA/B+7BMhHkXT4chg2MyboGdFGawYg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "8.4.0",
-        "@typescript-eslint/visitor-keys": "8.4.0"
+        "@typescript-eslint/types": "8.5.0",
+        "@typescript-eslint/visitor-keys": "8.5.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.4.0.tgz",
-      "integrity": "sha512-pu2PAmNrl9KX6TtirVOrbLPLwDmASpZhK/XU7WvoKoCUkdtq9zF7qQ7gna0GBZFN0hci0vHaSusiL2WpsQk37A==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.5.0.tgz",
+      "integrity": "sha512-N1K8Ix+lUM+cIDhL2uekVn/ZD7TZW+9/rwz8DclQpcQ9rk4sIL5CAlBC0CugWKREmDjBzI/kQqU4wkg46jWLYA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "8.4.0",
-        "@typescript-eslint/utils": "8.4.0",
+        "@typescript-eslint/typescript-estree": "8.5.0",
+        "@typescript-eslint/utils": "8.5.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.4.0.tgz",
-      "integrity": "sha512-T1RB3KQdskh9t3v/qv7niK6P8yvn7ja1mS7QK7XfRVL6wtZ8/mFs/FHf4fKvTA0rKnqnYxl/uHFNbnEt0phgbw==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.5.0.tgz",
+      "integrity": "sha512-qjkormnQS5wF9pjSi6q60bKUHH44j2APxfh9TQRXK8wbYVeDYYdYJGIROL87LGZZ2gz3Rbmjc736qyL8deVtdw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.4.0.tgz",
-      "integrity": "sha512-kJ2OIP4dQw5gdI4uXsaxUZHRwWAGpREJ9Zq6D5L0BweyOrWsL6Sz0YcAZGWhvKnH7fm1J5YFE1JrQL0c9dd53A==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.5.0.tgz",
+      "integrity": "sha512-vEG2Sf9P8BPQ+d0pxdfndw3xIXaoSjliG0/Ejk7UggByZPKXmJmw3GW5jV2gHNQNawBUyfahoSiCFVov0Ruf7Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "8.4.0",
-        "@typescript-eslint/visitor-keys": "8.4.0",
+        "@typescript-eslint/types": "8.5.0",
+        "@typescript-eslint/visitor-keys": "8.5.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -15891,24 +15258,24 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.4.0.tgz",
-      "integrity": "sha512-swULW8n1IKLjRAgciCkTCafyTHHfwVQFt8DovmaF69sKbOxTSFMmIZaSHjqO9i/RV0wIblaawhzvtva8Nmm7lQ==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.5.0.tgz",
+      "integrity": "sha512-6yyGYVL0e+VzGYp60wvkBHiqDWOpT63pdMV2CVG4LVDd5uR6q1qQN/7LafBZtAtNIn/mqXjsSeS5ggv/P0iECw==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.4.0",
-        "@typescript-eslint/types": "8.4.0",
-        "@typescript-eslint/typescript-estree": "8.4.0"
+        "@typescript-eslint/scope-manager": "8.5.0",
+        "@typescript-eslint/types": "8.5.0",
+        "@typescript-eslint/typescript-estree": "8.5.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.4.0.tgz",
-      "integrity": "sha512-zTQD6WLNTre1hj5wp09nBIDiOc2U5r/qmzo7wxPn4ZgAjHql09EofqhF9WF+fZHzL5aCyaIpPcT2hyxl73kr9A==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.5.0.tgz",
+      "integrity": "sha512-yTPqMnbAZJNy2Xq2XU8AdtOW9tJIr+UQb64aXB9f3B1498Zx9JorVgFJcZpEc9UBuCCrdzKID2RGAMkYcDtZOw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "8.4.0",
+        "@typescript-eslint/types": "8.5.0",
         "eslint-visitor-keys": "^3.4.3"
       }
     },
@@ -22780,6 +22147,12 @@
       "requires": {
         "readable-stream": "3"
       }
+    },
+    "tinyexec": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.0.tgz",
+      "integrity": "sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==",
+      "dev": true
     },
     "tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -94,14 +94,14 @@
     "@types/responselike": "^1.0.0"
   },
   "devDependencies": {
-    "@commitlint/cli": "^19.4.1",
-    "@commitlint/config-conventional": "^19.4.1",
+    "@commitlint/cli": "^19.5.0",
+    "@commitlint/config-conventional": "^19.5.0",
     "@redocly/openapi-cli": "^1.0.0-beta.95",
     "@redocly/cli": "^1.5.0",
     "@types/jest": "^29.5.12",
     "@types/js-yaml": "^4.0.9",
-    "@typescript-eslint/eslint-plugin": "^8.4.0",
-    "@typescript-eslint/parser": "^8.4.0",
+    "@typescript-eslint/eslint-plugin": "^8.5.0",
+    "@typescript-eslint/parser": "^8.5.0",
     "audit-ci": "^7.1.0",
     "browser-sync": "^3.0.2",
     "diff": "^7.0.0",

--- a/src/fspiop/v2_0_ISO20022/openapi.ts
+++ b/src/fspiop/v2_0_ISO20022/openapi.ts
@@ -519,7 +519,13 @@ export interface components {
          *     }
          */
         AccountIdentification4Choice: {
+            /** @description IBAN
+             *     International Bank Account Number (IBAN) - identifier used internationally by financial institutions to uniquely identify the account of a customer. Further specifications of the format and content of the IBAN can be found in the standard ISO 13616 "Banking and related financial services - International Bank Account Number (IBAN)" version 1997-10-01, or later revisions.
+             *      */
             IBAN?: components["schemas"]["IBAN2007Identifier"];
+            /** @description Other
+             *     Unique identification of an account, as assigned by the account servicer, using an identification scheme.
+             *      */
             Othr?: components["schemas"]["GenericAccountIdentification1"];
         } & (unknown | unknown);
         /**
@@ -531,7 +537,13 @@ export interface components {
          *     }
          */
         AccountSchemeName1Choice: {
+            /** @description Code
+             *     Name of the identification scheme, in a coded form as published in an external list.
+             *      */
             Cd?: components["schemas"]["ExternalAccountIdentification1Code"];
+            /** @description Proprietary
+             *     Name of the identification scheme, in a free text form.
+             *      */
             Prtry?: components["schemas"]["Max35Text"];
         } & (unknown | unknown);
         /**
@@ -545,6 +557,9 @@ export interface components {
          */
         ActiveCurrencyAndAmount: {
             ActiveCurrencyAndAmount: components["schemas"]["ActiveCurrencyAndAmount_SimpleType"];
+            /** @description Currency
+             *     Identification of the currency in which the account is held.
+             *      */
             Ccy: components["schemas"]["ActiveCurrencyCode"];
         };
         /**
@@ -578,6 +593,9 @@ export interface components {
          */
         ActiveOrHistoricCurrencyAndAmount: {
             ActiveOrHistoricCurrencyAndAmount: components["schemas"]["ActiveOrHistoricCurrencyAndAmount_SimpleType"];
+            /** @description Currency
+             *     Identification of the currency in which the account is held.
+             *      */
             Ccy: components["schemas"]["ActiveOrHistoricCurrencyCode"];
         };
         /**
@@ -594,6 +612,7 @@ export interface components {
         ActiveOrHistoricCurrencyCode: string;
         /**
          * @description AddressType2Code
+         *
          *     Specifies the type of address.
          *
          * @example ADDR
@@ -609,7 +628,13 @@ export interface components {
          *     }
          */
         AddressType3Choice: {
+            /** @description Code
+             *     Type of address expressed as a code.
+             *      */
             Cd?: components["schemas"]["AddressType2Code"];
+            /** @description Proprietary
+             *     Type of address expressed as a proprietary code.
+             *      */
             Prtry?: components["schemas"]["GenericIdentification30"];
         } & (unknown | unknown);
         /**
@@ -667,7 +692,14 @@ export interface components {
          *     }
          */
         BranchAndFinancialInstitutionIdentification6: {
+            /** @description FinancialInstitutionIdentification
+             *     Unique and unambiguous identification of a financial institution, as assigned under an internationally recognised or proprietary identification scheme.
+             *      */
             FinInstnId: components["schemas"]["FinancialInstitutionIdentification18"];
+            /** @description BranchIdentification
+             *     Definition: Identifies a specific branch of a financial institution.
+             *     Usage: This component should be used in case the identification information in the financial institution component does not provide identification up to branch level.
+             *      */
             BrnchId?: components["schemas"]["BranchData3"];
         };
         /**
@@ -676,24 +708,35 @@ export interface components {
          *
          * @example {
          *       "FinInstnId": {
-         *         "BICFI": "BUKBGB22"
+         *         "BICFI": "J5BMVH7D"
          *       },
          *       "BrnchId": {
-         *         "Id": 12345,
-         *         "Nm": "Oxford Street Branch",
+         *         "Id": 123,
+         *         "Nm": "Name",
          *         "PstlAdr": {
-         *           "Ctry": "GB",
-         *           "AdrLine": [
-         *             "1 Oxford Street",
-         *             "London",
-         *             "UK"
-         *           ]
+         *           "AdrTp": "ADDR",
+         *           "Dept": "Department",
+         *           "SubDept": "Sub department",
+         *           "StrtNm": "Street name",
+         *           "BldgNb": "Building number",
+         *           "PstCd": "Post code",
+         *           "TwnNm": "Town name",
+         *           "CtrySubDvsn": "Country subdivision",
+         *           "Ctry": "Country",
+         *           "AdrLine": "Address line"
          *         }
          *       }
          *     }
          */
         BranchAndFinancialInstitutionIdentification8: {
+            /** @description FinancialInstitutionIdentification
+             *     Unique and unambiguous identification of a financial institution or a branch of a financial institution.
+             *      */
             FinInstnId: components["schemas"]["FinancialInstitutionIdentification23"];
+            /** @description BranchIdentification
+             *
+             *      Identifies a specific branch of a financial institution.
+             *      */
             BrnchId?: components["schemas"]["BranchData5"];
         };
         /**
@@ -718,9 +761,21 @@ export interface components {
          *     }
          */
         BranchData3: {
+            /** @description Identification
+             *     Unique and unambiguous identification of a branch of a financial institution.
+             *      */
             Id?: components["schemas"]["Max35Text"];
+            /** @description Legal Entity Identifier
+             *     Legal entity identification for the branch of the financial institution.
+             *      */
             LEI?: components["schemas"]["LEIIdentifier"];
+            /** @description Name
+             *     Name by which an agent is known and which is usually used to identify that agent.
+             *      */
             Nm?: components["schemas"]["Max140Text"];
+            /** @description Postal Address
+             *     Information that locates and identifies a specific address, as defined by postal services.
+             *      */
             PstlAdr?: components["schemas"]["PostalAddress24"];
         };
         /**
@@ -729,21 +784,38 @@ export interface components {
          *
          * @example {
          *       "Id": 123,
-         *       "Nm": "Oxford Street Branch",
+         *       "LEI": 123,
+         *       "Nm": "Name",
          *       "PstlAdr": {
-         *         "Ctry": "GB",
-         *         "AdrLine": [
-         *           "1 Oxford Street",
-         *           "London",
-         *           "UK"
-         *         ]
+         *         "AdrTp": "ADDR",
+         *         "Dept": "Department",
+         *         "SubDept": "Sub department",
+         *         "StrtNm": "Street name",
+         *         "BldgNb": "Building number",
+         *         "PstCd": "Post code",
+         *         "TwnNm": "Town name",
+         *         "CtrySubDvsn": "Country subdivision",
+         *         "Ctry": "Country",
+         *         "AdrLine": "Address line"
          *       }
          *     }
          */
         BranchData5: {
+            /** @description identification
+             *     Unique and unambiguous identification of a branch of a financial institution.
+             *      */
             Id?: components["schemas"]["Max35Text"];
+            /** @description LEI
+             *     Legal entity identification for the branch of the financial institution.
+             *      */
             LEI?: components["schemas"]["LEIIdentifier"];
+            /** @description Name
+             *     Name by which an agent is known and which is usually used to identify that agent.
+             *      */
             Nm?: components["schemas"]["Max140Text"];
+            /** @description PostalAddress
+             *     Information that locates and identifies a specific address, as defined by postal services.
+             *      */
             PstlAdr?: components["schemas"]["PostalAddress27"];
         };
         /**
@@ -765,10 +837,27 @@ export interface components {
          *     }
          */
         CashAccount40: {
+            /** @description Identification
+             *     Unique and unambiguous identification for the account between the account owner and the account servicer.
+             *      */
             Id?: components["schemas"]["AccountIdentification4Choice"];
+            /** @description Type
+             *     Specifies the nature, or use of the account.
+             *      */
             Tp?: components["schemas"]["CashAccountType2Choice"];
+            /** @description Currency
+             *     Definition: Identification of the currency in which the account is held.
+             *     Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account.
+             *      */
             Ccy?: components["schemas"]["ActiveOrHistoricCurrencyCode"];
+            /** @description Name
+             *     Definition: Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account.
+             *     Usage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number.
+             *      */
             Nm?: components["schemas"]["Max70Text"];
+            /** @description Proxy
+             *     Specifies an alternate assumed name for the identification of the account.
+             *      */
             Prxy?: components["schemas"]["ProxyAccountIdentification1"];
         };
         /**
@@ -780,7 +869,13 @@ export interface components {
          *     }
          */
         CashAccountType2Choice: {
+            /** @description Code
+             *     Account type, in a coded form.
+             *      */
             Cd?: components["schemas"]["ExternalCashAccountType1Code"];
+            /** @description Proprietary
+             *     Nature or use of the account in a proprietary form.
+             *      */
             Prtry?: components["schemas"]["Max35Text"];
         } & (unknown | unknown);
         /**
@@ -792,7 +887,13 @@ export interface components {
          *     }
          */
         CategoryPurpose1Choice: {
+            /** @description Code
+             *     Category purpose, as published in an external category purpose code list.
+             *      */
             Cd?: components["schemas"]["ExternalCategoryPurpose1Code"];
+            /** @description Proprietary
+             *     Category purpose, in a proprietary form.
+             *      */
             Prtry?: components["schemas"]["Max35Text"];
         } & (unknown | unknown);
         /**
@@ -809,18 +910,28 @@ export interface components {
         ChargeBearerType1Code: "DEBT" | "CRED" | "SHAR" | "SLEV";
         /**
          * ChargeType3Choice
-         * @description ChargeType3Choice Specifies the type of charge.
+         * @description ChargeType3Choice
+         *     Specifies the type of charge.
+         *
          * @example {
          *       "Cd": "CASH"
          *     }
          */
         ChargeType3Choice: {
+            /** @description Code
+             *     Charge type, in a coded form.
+             *      */
             Cd?: components["schemas"]["ExternalChargeType1Code"];
+            /** @description Proprietary
+             *     Type of charge in a proprietary form, as defined by the issuer.
+             *      */
             Prtry?: components["schemas"]["GenericIdentification3"];
         } & (unknown | unknown);
         /**
          * Charges16
          * @description NOTE: Unsure on description.
+         *
+         *     Seemingly a generic schema for charges, with an amount, agent, and type.
          *
          * @example {
          *       "Amt": {
@@ -841,8 +952,19 @@ export interface components {
          *     }
          */
         Charges16: {
+            /** @description Amount
+             *
+             *      Transaction charges to be paid by the charge bearer.
+             *      */
             Amt: components["schemas"]["ActiveOrHistoricCurrencyAndAmount"];
+            /** @description Agent
+             *     Agent that takes the transaction charges or to which the transaction charges are due.
+             *      */
             Agt: components["schemas"]["BranchAndFinancialInstitutionIdentification8"];
+            /** @description Type
+             *
+             *      Defines the type of charges.
+             *      */
             Tp?: components["schemas"]["ChargeType3Choice"];
         };
         /**
@@ -866,7 +988,13 @@ export interface components {
          *     }
          */
         ClearingSystemIdentification2Choice: {
+            /** @description Code
+             *     Identification of a member of a clearing system
+             *      */
             Cd?: components["schemas"]["ExternalClearingSystemIdentification1Code"];
+            /** @description Proprietary
+             *     Identification code for a clearing system, that has not yet been identified in the list of clearing systems.
+             *      */
             Prtry?: components["schemas"]["Max35Text"];
         } & (unknown | unknown);
         /**
@@ -881,7 +1009,13 @@ export interface components {
          *     }
          */
         ClearingSystemMemberIdentification2: {
+            /** @description ClearingSystemIdentification.
+             *     Specification of a pre-agreed offering between clearing agents or the channel through which the payment instruction is processed.
+             *      */
             ClrSysId?: components["schemas"]["ClearingSystemIdentification2Choice"];
+            /** @description MemberIdentification.
+             *     Identification of a member of a clearing system.
+             *      */
             MmbId: components["schemas"]["Max35Text"];
         };
         /**
@@ -899,18 +1033,57 @@ export interface components {
          *     }
          */
         Contact13: {
+            /** @description NamePrefix
+             *     Specifies the terms used to formally address a person.
+             *      */
             NmPrfx?: components["schemas"]["NamePrefix2Code"];
+            /** @description Name
+             *     Name by which a party is known and which is usually used to identify that party.
+             *      */
             Nm?: components["schemas"]["Max140Text"];
+            /** @description PhoneNumber
+             *     Collection of information that identifies a phone number, as defined by telecom services.
+             *      */
             PhneNb?: components["schemas"]["PhoneNumber"];
+            /** @description MobilePhoneNumber
+             *     Collection of information that identifies a mobile phone number, as defined by telecom services.
+             *      */
             MobNb?: components["schemas"]["PhoneNumber"];
+            /** @description FaxNumber
+             *     Collection of information that identifies a fax number, as defined by telecom services.
+             *      */
             FaxNb?: components["schemas"]["PhoneNumber"];
+            /** @description URLAddress
+             *     Address for the Universal Resource Locator (URL), for example an address used over the www (HTTP) service.
+             *      */
             URLAdr?: components["schemas"]["Max2048Text"];
+            /** @description EmailAddress
+             *     Address for electronic mail (e-mail).
+             *      */
             EmailAdr?: components["schemas"]["Max256Text"];
+            /** @description EmailPurpose
+             *     Purpose for which an email address may be used.
+             *      */
             EmailPurp?: components["schemas"]["Max35Text"];
+            /** @description JobTitle
+             *     Title of the function.
+             *      */
             JobTitl?: components["schemas"]["Max35Text"];
+            /** @description Responsibility
+             *     Role of a person in an organisation.
+             *      */
             Rspnsblty?: components["schemas"]["Max35Text"];
+            /** @description Department
+             *     Identification of a division of a large organisation or building.
+             *      */
             Dept?: components["schemas"]["Max70Text"];
+            /** @description OtherContact
+             *     Contact details in another form.
+             *      */
             Othr?: components["schemas"]["OtherContact1"];
+            /** @description PreferredContactMethod
+             *     Preferred method used to reach the contact.
+             *      */
             PrefrdMtd?: components["schemas"]["PreferredContactMethod2Code"];
         };
         /**
@@ -927,21 +1100,59 @@ export interface components {
          *     }
          */
         Contact4: {
+            /** @description NamePrefix
+             *     Name prefix to be used before the name of the person.
+             *      */
             NmPrfx?: components["schemas"]["NamePrefix2Code"];
+            /** @description Name
+             *     Name by which a party is known and which is usually used to identify that party.
+             *      */
             Nm?: components["schemas"]["Max140Text"];
+            /** @description PhoneNumber
+             *     Collection of information that identifies a phone number, as defined by telecom services.
+             *      */
             PhneNb?: components["schemas"]["PhoneNumber"];
+            /** @description MobilePhoneNumber
+             *     Collection of information that identifies a mobile phone number, as defined by telecom services.
+             *      */
             MobNb?: components["schemas"]["PhoneNumber"];
+            /** @description FaxNumber
+             *     Collection of information that identifies a fax number, as defined by telecom services.
+             *      */
             FaxNb?: components["schemas"]["PhoneNumber"];
+            /** @description EmailAddress
+             *     Address for electronic mail (e-mail).
+             *      */
             EmailAdr?: components["schemas"]["Max2048Text"];
+            /** @description EmailPurpose
+             *     Purpose for which an email address may be used.
+             *      */
             EmailPurp?: components["schemas"]["Max35Text"];
+            /** @description JobTitle
+             *     Title of the function.
+             *      */
             JobTitl?: components["schemas"]["Max35Text"];
+            /** @description Responsibility
+             *     Role of a person in an organisation.
+             *      */
             Rspnsblty?: components["schemas"]["Max35Text"];
+            /** @description Department
+             *     Identification of a division of a large organisation or building.
+             *      */
             Dept?: components["schemas"]["Max70Text"];
+            /** @description Other
+             *     : Contact details in another form.
+             *      */
             Othr?: components["schemas"]["OtherContact1"];
+            /** @description PreferredMethod
+             *     Preferred method used to reach the contact.
+             *      */
             PrefrdMtd?: components["schemas"]["PreferredContactMethod1Code"];
         };
         /**
          * CountryCode
+         * @description Code to identify a country, a dependency, or another area of particular geopolitical interest, on the basis of country names obtained from the United Nations (ISO 3166, Alpha-2 code).
+         *
          * @example US
          */
         CountryCode: string;
@@ -1053,23 +1264,80 @@ export interface components {
          *     }
          */
         CreditTransferTransaction67: {
+            /** @description PaymentIdentification
+             *     Set of elements used to reference a payment instruction.
+             *      */
             PmtId: components["schemas"]["PaymentIdentification13"];
+            /** @description PaymentTypeInformation
+             *
+             *      Set of elements used to further specify the type of transaction.
+             *      */
             PmtTpInf?: components["schemas"]["PaymentTypeInformation28"];
+            /** @description InterbankSettlementAmount
+             *     Amount of money moved between the instructing agent and the instructed agent.
+             *      */
             IntrBkSttlmAmt: components["schemas"]["ActiveCurrencyAndAmount"];
+            /** @description InstructedAmount
+             *     Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.
+             *      */
             InstdAmt?: components["schemas"]["ActiveOrHistoricCurrencyAndAmount"];
+            /** @description ExchangeRate
+             *     Factor used to convert an amount from one currency into another. This reflects the price at which one currency was bought with another currency.
+             *      */
             XchgRate?: components["schemas"]["BaseOneRate"];
+            /** @description ChargeBearer
+             *     Specifies which party/parties will bear the charges associated with the processing of the payment transaction.
+             *      */
             ChrgBr: components["schemas"]["ChargeBearerType1Code"];
+            /** @description ChargesInformation
+             *
+             *      Provides information on the charges to be paid by the charge bearer(s) related to the
+             *     payment transaction
+             *      */
             ChrgsInf?: components["schemas"]["Charges16"];
+            /** @description Debtor
+             *     Party that owes an amount of money to the (ultimate) creditor.
+             *      */
             Dbtr: components["schemas"]["PartyIdentification272"];
+            /** @description DebtorAccount
+             *     Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction.
+             *      */
             DbtrAcct?: components["schemas"]["CashAccount40"];
+            /** @description DebtorAgent
+             *     Financial institution servicing an account for the debtor.
+             *      */
             DbtrAgt: components["schemas"]["BranchAndFinancialInstitutionIdentification8"];
+            /** @description CreditorAgent
+             *     Financial institution servicing an account for the creditor.
+             *      */
             CdtrAgt: components["schemas"]["BranchAndFinancialInstitutionIdentification8"];
+            /** @description Creditor
+             *     Party to which an amount of money is due.
+             *      */
             Cdtr: components["schemas"]["PartyIdentification272"];
+            /** @description CreditorAccount
+             *     Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction.
+             *      */
             CdtrAcct?: components["schemas"]["CashAccount40"];
+            /** @description InstructionForCreditorAgent
+             *     Set of elements used to provide information on the remittance advice.
+             *      */
             InstrForCdtrAgt?: components["schemas"]["InstructionForCreditorAgent3"];
+            /** @description InstructionForNextAgent
+             *     Set of elements used to provide information on the remittance advice.
+             *      */
             InstrForNxtAgt?: components["schemas"]["InstructionForNextAgent1"];
+            /** @description Purpose
+             *     Underlying reason for the payment transaction.
+             *      */
             Purp?: components["schemas"]["Purpose2Choice"];
+            /** @description RegulatoryReporting
+             *     Information needed due to regulatory and statutory requirements.
+             *      */
             RgltryRptg?: components["schemas"]["RegulatoryReporting3"];
+            /** @description Tax
+             *     Provides details on the tax.
+             *      */
             Tax?: components["schemas"]["TaxData1"];
             VrfctnOfTerms?: components["schemas"]["CryptographicLockChoice"];
         };
@@ -1131,17 +1399,54 @@ export interface components {
          *     }
          */
         CreditTransferTransaction68: {
+            /** @description PaymentIdentification
+             *     Set of elements used to reference a payment instruction.
+             *      */
             PmtId: components["schemas"]["PaymentIdentification13"];
+            /** @description PaymentTypeInformation
+             *
+             *      Set of elements used to further specify the type of transaction.
+             *      */
             PmtTpInf?: components["schemas"]["PaymentTypeInformation28"];
+            /** @description InterbankSettlementAmount
+             *     Amount of money moved between the instructing agent and the instructed agent.
+             *      */
             IntrBkSttlmAmt: components["schemas"]["ActiveCurrencyAndAmount"];
+            /** @description Debtor
+             *     Party that owes an amount of money to the (ultimate) creditor.
+             *      */
             Dbtr: components["schemas"]["BranchAndFinancialInstitutionIdentification8"];
+            /** @description DebtorAccount
+             *     Account used to process a payment.
+             *      */
             DbtrAcct?: components["schemas"]["CashAccount40"];
+            /** @description DebtorAgent
+             *     Financial institution servicing an account for the debtor.
+             *      */
             DbtrAgt?: components["schemas"]["BranchAndFinancialInstitutionIdentification8"];
+            /** @description CreditorAgent
+             *     Financial institution servicing an account for the creditor.
+             *      */
             CdtrAgt?: components["schemas"]["BranchAndFinancialInstitutionIdentification8"];
+            /** @description Creditor
+             *     Party to which an amount of money is due.
+             *      */
             Cdtr: components["schemas"]["BranchAndFinancialInstitutionIdentification8"];
+            /** @description CreditorAccount
+             *     Account to which a credit entry is made.
+             *      */
             CdtrAcct?: components["schemas"]["CashAccount40"];
+            /** @description InstructionForCreditorAgent
+             *     Set of elements used to provide information on the remittance advice.
+             *      */
             InstrForCdtrAgt?: components["schemas"]["InstructionForCreditorAgent3"];
+            /** @description Purpose
+             *     Underlying reason for the payment transaction.
+             *      */
             Purp?: components["schemas"]["Purpose2Choice"];
+            /** @description VerificationOfTerms
+             *     Set of elements used to provide information on the underlying terms of the transaction.
+             *      */
             VrfctnOfTerms?: components["schemas"]["CryptographicLockChoice"];
         };
         /**
@@ -1168,9 +1473,21 @@ export interface components {
          *     }
          */
         DateAndPlaceOfBirth1: {
+            /** @description BirthDate
+             *     Date on which a person is born.
+             *      */
             BirthDt: components["schemas"]["ISODate"];
+            /** @description ProvinceOfBirth
+             *     Province where a person was born.
+             *      */
             PrvcOfBirth?: components["schemas"]["Max35Text"];
+            /** @description CityOfBirth
+             *     City where a person was born.
+             *      */
             CityOfBirth: components["schemas"]["Max35Text"];
+            /** @description CountryOfBirth
+             *     Country where a person was born.
+             *      */
             CtryOfBirth: components["schemas"]["CountryCode"];
         };
         /**
@@ -1178,12 +1495,18 @@ export interface components {
          * @description Range of time defined by a start date and an end date.
          *
          * @example {
-         *       "FrDt": "2020-01-01",
-         *       "ToDt": "2020-12-31"
+         *       "FrDt": "2022-01-01T00:00:00.000Z",
+         *       "ToDt": "2022-12-31T23:59:59.999Z"
          *     }
          */
         DatePeriod2: {
+            /** @description FromDate
+             *     Start date of the range.
+             *      */
             FrDt: components["schemas"]["ISODate"];
+            /** @description ToDate
+             *     End date of the range.
+             *      */
             ToDt: components["schemas"]["ISODate"];
         };
         /**
@@ -1232,89 +1555,93 @@ export interface components {
          * Execute_FIToFICustomerCreditTransferV13
          * @example {
          *       "GrpHdr": {
-         *         "MsgId": 123456789,
+         *         "MsgId": 12345,
          *         "CreDtTm": "2020-01-01T00:00:00Z",
+         *         "PmtInstrXpryDtTm": "2020-01-01T00:00:00Z",
          *         "NbOfTxs": 1,
-         *         "CtrlSum": 100,
-         *         "InitgPty": {
-         *           "Nm": "Initiating Party Name",
-         *           "Id": {
-         *             "OrgId": {
-         *               "Othr": [
-         *                 {
-         *                   "Id": 123456789,
-         *                   "SchmeNm": {
-         *                     "Cd": 91
-         *                   }
-         *                 }
-         *               ]
+         *         "SttlmInf": {
+         *           "SttlmMtd": "INDA",
+         *           "SttlmAcct": {
+         *             "Id": {
+         *               "IBAN": 123
          *             }
+         *           },
+         *           "SttlmAcctOwnr": {
+         *             "Nm": "John Doe"
+         *           },
+         *           "SttlmAcctSvcr": {
+         *             "BICFI": 123
          *           }
          *         },
-         *         "FwdgAgt": {
-         *           "FinInstnId": {
-         *             "BICFI": "BBBBBBBB"
+         *         "CdtTrfTxInf": {
+         *           "PmtId": {
+         *             "InstrId": 123,
+         *             "EndToEndId": 123
+         *           },
+         *           "PmtTpInf": {
+         *             "InstrPrty": "NORM"
+         *           },
+         *           "InstdAmt": {
+         *             "Amt": 123,
+         *             "Ccy": "EUR"
+         *           },
+         *           "ChrgBr": "SLEV",
+         *           "CdtrAgt": {
+         *             "FinInstnId": {
+         *               "BICFI": 123
+         *             }
+         *           },
+         *           "Cdtr": {
+         *             "Nm": "John Doe"
+         *           },
+         *           "CdtrAcct": {
+         *             "Id": {
+         *               "IBAN": 123
+         *             }
+         *           },
+         *           "RmtInf": {
+         *             "Ustrd": "Test"
          *           }
          *         }
          *       },
          *       "CdtTrfTxInf": {
          *         "PmtId": {
-         *           "InstrId": 123456789,
-         *           "EndToEndId": 123456789
+         *           "InstrId": 123,
+         *           "EndToEndId": 123
          *         },
          *         "PmtTpInf": {
-         *           "InstrPrty": "NORM",
-         *           "CtgyPurp": {
-         *             "Cd": "SUPP"
-         *           }
+         *           "InstrPrty": "NORM"
          *         },
-         *         "InstrForCdtrAgt": {
-         *           "FinInstnId": {
-         *             "BICFI": "AAAAAAAA"
-         *           }
+         *         "InstdAmt": {
+         *           "Amt": 123,
+         *           "Ccy": "EUR"
          *         },
+         *         "ChrgBr": "SLEV",
          *         "CdtrAgt": {
          *           "FinInstnId": {
-         *             "BICFI": "AAAAAAAA"
+         *             "BICFI": 123
          *           }
          *         },
          *         "Cdtr": {
-         *           "Nm": "Creditor Name",
-         *           "PstlAdr": {
-         *             "AdrLine": [
-         *               "Creditor Address Line 1",
-         *               "Creditor Address Line 2",
-         *               "Creditor Address Line 3",
-         *               "Creditor Address Line 4",
-         *               "Creditor Address Line 5"
-         *             ]
-         *           },
-         *           "Id": {
-         *             "OrgId": {
-         *               "Othr": [
-         *                 {
-         *                   "Id": 123456789,
-         *                   "SchmeNm": {
-         *                     "Cd": 91
-         *                   }
-         *                 }
-         *               ]
-         *             }
-         *           }
+         *           "Nm": "John Doe"
          *         },
          *         "CdtrAcct": {
          *           "Id": {
-         *             "IBAN": "DE87123456781234567890"
+         *             "IBAN": 123
          *           }
          *         },
          *         "RmtInf": {
-         *           "Ustrd": "Remittance Information"
+         *           "Ustrd": "Test"
          *         }
          *       }
          *     }
          */
         Execute_FIToFICustomerCreditTransferV13: {
+            /** @description GroupHeader.
+             *      */
             GrpHdr: components["schemas"]["GroupHeader129"];
+            /** @description CreditTransferTransactionInformation.
+             *      */
             CdtTrfTxInf: components["schemas"]["CreditTransferTransaction67"];
         };
         /**
@@ -1437,53 +1764,130 @@ export interface components {
          *     }
          */
         FinancialIdentificationSchemeName1Choice: {
+            /** @description Code
+             *     Name of the identification scheme, in a coded form as published in an external list.
+             *      */
             Cd?: components["schemas"]["ExternalFinancialInstitutionIdentification1Code"];
+            /** @description Proprietary
+             *     Name of the identification scheme, in a free text form.
+             *      */
             Prtry?: components["schemas"]["Max35Text"];
         } & (unknown | unknown);
         /**
          * FinancialInstitutionIdentification18
          * @example {
-         *       "BICFI": "BUKBGB22",
-         *       "Nm": "Barclays Bank Plc",
+         *       "BICFI": "J5BMVH7D",
+         *       "ClrSysMmbId": {
+         *         "ClrSysId": 1234,
+         *         "MmbId": 123
+         *       },
+         *       "LEI": 123,
+         *       "Nm": "Name",
          *       "PstlAdr": {
-         *         "Ctry": "GB",
-         *         "AdrLine": [
-         *           "1 Churchill Place",
-         *           "London",
-         *           "UK"
-         *         ]
+         *         "AdrTp": "ADDR",
+         *         "Dept": "Department",
+         *         "SubDept": "Sub department",
+         *         "StrtNm": "Street name",
+         *         "BldgNb": "Building number",
+         *         "PstCd": "Post code",
+         *         "TwnNm": "Town name",
+         *         "CtrySubDvsn": "Country subdivision",
+         *         "Ctry": "Country",
+         *         "AdrLine": "Address line"
+         *       },
+         *       "Othr": {
+         *         "Id": 123,
+         *         "SchmeNm": {
+         *           "Cd": 123,
+         *           "Prtry": 123
+         *         },
+         *         "Issr": 123
          *       }
          *     }
          */
         FinancialInstitutionIdentification18: {
+            /** @description BICFI
+             *     Code allocated to a financial institution by the ISO 9362 Registration Authority as described in ISO 9362 "Banking - Banking telecommunication messages - Business identifier code (BIC)"
+             *      */
             BICFI?: components["schemas"]["BICFIDec2014Identifier"];
+            /** @description ClearingSystemMemberIdentification
+             *     Information used to identify a member within a clearing system
+             *      */
             ClrSysMmbId?: components["schemas"]["ClearingSystemMemberIdentification2"];
+            /** @description LEI
+             *     Legal entity identifier of the financial institution.
+             *      */
             LEI?: components["schemas"]["LEIIdentifier"];
+            /** @description Name
+             *     Name by which an agent is known and which is usually used to identify that agent
+             *      */
             Nm?: components["schemas"]["Max140Text"];
+            /** @description PostalAddress
+             *     Information that locates and identifies a specific address, as defined by postal services.
+             *      */
             PstlAdr?: components["schemas"]["PostalAddress24"];
+            /** @description Other
+             *     Unique identification of an agent, as assigned by an institution, using an identification scheme.
+             *      */
             Othr?: components["schemas"]["GenericFinancialIdentification1"];
         };
         /**
          * FinancialInstitutionIdentification23
          * @example {
-         *       "BICFI": "BUKBGB22",
-         *       "Nm": "Barclays Bank Plc",
+         *       "BICFI": "J5BMVH7D",
+         *       "ClrSysMmbId": {
+         *         "ClrSysId": {
+         *           "Cd": "CHQB"
+         *         },
+         *         "MmbId": 123456789
+         *       },
+         *       "LEI": 123,
+         *       "Nm": "Name",
          *       "PstlAdr": {
-         *         "Ctry": "GB",
-         *         "AdrLine": [
-         *           "1 Churchill Place",
-         *           "London",
-         *           "UK"
-         *         ]
+         *         "AdrTp": "ADDR",
+         *         "Dept": "Department",
+         *         "SubDept": "Sub department",
+         *         "StrtNm": "Street name",
+         *         "BldgNb": "Building number",
+         *         "PstCd": "Post code",
+         *         "TwnNm": "Town name",
+         *         "CtrySubDvsn": "Country subdivision",
+         *         "Ctry": "Country",
+         *         "AdrLine": "Address line"
+         *       },
+         *       "Othr": {
+         *         "Id": 123,
+         *         "SchmeNm": {
+         *           "Cd": "CHQB"
+         *         },
+         *         "Issr": 123
          *       }
          *     }
          */
         FinancialInstitutionIdentification23: {
+            /** @description BICFI
+             *     Code allocated to a financial institution by the ISO 9362 Registration Authority as described in ISO 9362 "Banking - Banking telecommunication messages - Business identifier code (BIC)"
+             *      */
             BICFI?: components["schemas"]["BICFIDec2014Identifier"];
+            /** @description ClearingSystemMemberIdentification
+             *     Information used to identify a member within a clearing system
+             *      */
             ClrSysMmbId?: components["schemas"]["ClearingSystemMemberIdentification2"];
+            /** @description LEI
+             *     Legal entity identifier of the financial institution.
+             *      */
             LEI?: components["schemas"]["LEIIdentifier"];
+            /** @description Name
+             *     Name by which an agent is known and which is usually used to identify that agent
+             *      */
             Nm?: components["schemas"]["Max140Text"];
+            /** @description PostalAddress
+             *     Information that locates and identifies a specific address, as defined by postal services.
+             *      */
             PstlAdr?: components["schemas"]["PostalAddress27"];
+            /** @description Other
+             *     Unique identification of an agent, as assigned by an institution, using an identification scheme.
+             *      */
             Othr?: components["schemas"]["GenericFinancialIdentification1"];
         };
         /**
@@ -1620,6 +2024,9 @@ export interface components {
          *     }
          */
         FxRequest_FICreditTransferProposal: {
+            /** @description GroupHeader
+             *     Set of characteristics shared by all individual transactions included in the message.
+             *      */
             GrpHdr: components["schemas"]["GroupHeader113"];
         };
         /**
@@ -1729,7 +2136,13 @@ export interface components {
          *     }
          */
         FxResponse_FICreditTransferConfirmation: {
+            /** @description GroupHeader
+             *     Set of characteristics shared by all individual transactions included in the message.
+             *      */
             GrpHdr: components["schemas"]["GroupHeader113"];
+            /** @description CreditTransferTransactionInformation
+             *     Set of elements providing information specific to the individual credit transfer(s).
+             *      */
             CdtTrfTxInf: components["schemas"]["CreditTransferTransaction68"];
         };
         /**
@@ -1808,7 +2221,13 @@ export interface components {
          *     }
          */
         Fxecute_FinancialInstitutionCreditTransferV12: {
+            /** @description GroupHeader.
+             *     Set of characteristics shared by all individual transactions included in the message.
+             *      */
             GrpHdr: components["schemas"]["GroupHeader129"];
+            /** @description CreditTransferTransactionInformation.
+             *     Set of elements providing information specific to the individual credit transfer(s).
+             *      */
             CdtTrfTxInf: components["schemas"]["CreditTransferTransaction68"];
         };
         /**
@@ -1822,8 +2241,17 @@ export interface components {
          *     }
          */
         GenericAccountIdentification1: {
+            /** @description Identification
+             *     Identification assigned by an institution.
+             *      */
             Id: components["schemas"]["Max34Text"];
+            /** @description SchemeName
+             *     Name of the identification scheme.
+             *      */
             SchmeNm?: components["schemas"]["AccountSchemeName1Choice"];
+            /** @description Issuer
+             *     Entity that assigns the identification.
+             *      */
             Issr?: components["schemas"]["Max35Text"];
         };
         /**
@@ -1837,8 +2265,17 @@ export interface components {
          *     }
          */
         GenericFinancialIdentification1: {
+            /** @description Identification
+             *     Unique and unambiguous identification of a person.
+             *      */
             Id: components["schemas"]["Max35Text"];
+            /** @description SchemeName
+             *     Name of the identification scheme.
+             *      */
             SchmeNm?: components["schemas"]["FinancialIdentificationSchemeName1Choice"];
+            /** @description Issuer
+             *     Entity that assigns the identification.
+             *      */
             Issr?: components["schemas"]["Max35Text"];
         };
         /**
@@ -1849,7 +2286,13 @@ export interface components {
          *     }
          */
         GenericIdentification3: {
+            /** @description Identification
+             *     Name or number assigned by an entity to enable recognition of that entity, for example, account identifier.
+             *      */
             Id: components["schemas"]["Max35Text"];
+            /** @description Issuer
+             *     Entity that assigns the identification.
+             *      */
             Issr?: components["schemas"]["Max35Text"];
         };
         /**
@@ -1861,8 +2304,17 @@ export interface components {
          *     }
          */
         GenericIdentification30: {
+            /** @description Identification
+             *     Proprietary information, often a code, issued by the data source scheme issuer
+             *      */
             Id: components["schemas"]["Exact4AlphaNumericText"];
+            /** @description Issuer
+             *     Entity that assigns the identification.
+             *      */
             Issr: components["schemas"]["Max35Text"];
+            /** @description SchemeName
+             *     Short textual description of the scheme.
+             *      */
             SchmeNm?: components["schemas"]["Max35Text"];
         };
         /**
@@ -1876,8 +2328,17 @@ export interface components {
          *     }
          */
         GenericOrganisationIdentification1: {
+            /** @description Identification
+             *     Identification assigned by an institution.
+             *      */
             Id: components["schemas"]["Max35Text"];
+            /** @description SchemeName
+             *     Name of the identification scheme.
+             *      */
             SchmeNm?: components["schemas"]["OrganisationIdentificationSchemeName1Choice"];
+            /** @description Issuer
+             *     Entity that assigns the identification.
+             *      */
             Issr?: components["schemas"]["Max35Text"];
         };
         /**
@@ -1891,8 +2352,16 @@ export interface components {
          *     }
          */
         GenericOrganisationIdentification3: {
+            /** @description Identification
+             *     Identification assigned by an institution.
+             *      */
             Id: components["schemas"]["Max256Text"];
+            /** @description SchemeName
+             *     Name of the identification scheme. */
             SchmeNm?: components["schemas"]["OrganisationIdentificationSchemeName1Choice"];
+            /** @description Issuer
+             *     Entity that assigns the identification.
+             *      */
             Issr?: components["schemas"]["Max35Text"];
         };
         /**
@@ -1906,8 +2375,17 @@ export interface components {
          *     }
          */
         GenericPersonIdentification1: {
+            /** @description Identification
+             *     Unique and unambiguous identification of a person.
+             *      */
             Id: components["schemas"]["Max35Text"];
+            /** @description SchemeName
+             *     Name of the identification scheme.
+             *      */
             SchmeNm?: components["schemas"]["PersonIdentificationSchemeName1Choice"];
+            /** @description Issuer
+             *     Entity that assigns the identification.
+             *      */
             Issr?: components["schemas"]["Max35Text"];
         };
         /**
@@ -1921,8 +2399,17 @@ export interface components {
          *     }
          */
         GenericPersonIdentification2: {
+            /** @description Identification
+             *     Unique and unambiguous identification of a person.
+             *      */
             Id: components["schemas"]["Max256Text"];
+            /** @description SchemeName
+             *     Name of the identification scheme.
+             *      */
             SchmeNm?: components["schemas"]["PersonIdentificationSchemeName1Choice"];
+            /** @description Issuer
+             *     Entity that assigns the identification.
+             *      */
             Issr?: components["schemas"]["Max35Text"];
         };
         /**
@@ -1994,81 +2481,104 @@ export interface components {
          *     }
          */
         GetPartiesError_IdentificationVerificationReportV03: {
+            /** @description Assignment
+             *     Information related to the identification assignment.
+             *      */
             Assgnmt: components["schemas"]["IdentificationAssignment3"];
+            /** @description Report
+             *     Information concerning the verification of the identification data for which verification was requested.
+             *      */
             Rpt: components["schemas"]["VerificationReport4"];
+            /** @description SupplementaryData
+             *     Additional information that cannot be captured in the structured elements and/or any other specific block.
+             *      */
             SplmtryData?: components["schemas"]["SupplementaryData1"];
         };
         /**
          * GetParties_IdentificationVerificationReportV03
          * @example {
          *       "Assgnmt": {
-         *         "Id": 123,
-         *         "CreDtTm": "2013-03-07T16:30:00",
+         *         "MsgId": 123,
+         *         "CreDtTm": "2020-01-01T00:00:00Z",
          *         "Assgnr": {
-         *           "Id": {
-         *             "Id": 123,
-         *             "SchmeNm": {
-         *               "Cd": "IBAN"
-         *             },
-         *             "Issr": "BIC"
+         *           "OrgId": {
+         *             "Othr": {
+         *               "Id": 123,
+         *               "SchmeNm": {
+         *                 "Cd": "BIC"
+         *               },
+         *               "Issr": "BIC"
+         *             }
          *           }
          *         },
          *         "Assgne": {
-         *           "Id": {
-         *             "Id": 123,
-         *             "SchmeNm": {
-         *               "Cd": "IBAN"
-         *             },
-         *             "Issr": "BIC"
+         *           "OrgId": {
+         *             "Othr": {
+         *               "Id": "DFSPID"
+         *             }
          *           }
          *         }
          *       },
          *       "Rpt": {
-         *         "Id": 123,
-         *         "CreDtTm": "2013-03-07T16:30:00",
-         *         "RptgPty": {
-         *           "Id": {
-         *             "Id": 123,
-         *             "SchmeNm": {
-         *               "Cd": "IBAN"
+         *         "OrgnlId": 12345678,
+         *         "Vrfctn": true,
+         *         "UpdtdPtyAndAcctId": {
+         *           "Pty": {
+         *             "Nm": "John Doe",
+         *             "PstlAdr": {
+         *               "AdrTp": "ADDR",
+         *               "Dept": "Dept",
+         *               "SubDept": "SubDept",
+         *               "StrtNm": "StrtNm",
+         *               "BldgNb": "BldgNb",
+         *               "BldgNm": "BldgNm",
+         *               "Flr": "Flr",
+         *               "PstBx": "PstBx",
+         *               "Room": "Room",
+         *               "PstCd": "PstCd",
+         *               "TwnNm": "TwnNm",
+         *               "TwnLctnNm": "TwnLctnNm",
+         *               "DstrctNm": "DstrctNm",
+         *               "CtrySubDvsn": "CtrySubDvsn",
+         *               "Ctry": "Ctry",
+         *               "AdrLine": "AdrLine"
          *             },
-         *             "Issr": "BIC"
-         *           }
-         *         },
-         *         "RptdPty": {
-         *           "Id": {
-         *             "Id": 123,
-         *             "SchmeNm": {
-         *               "Cd": "IBAN"
+         *             "Id": {
+         *               "OrgId": {
+         *                 "Othr": {
+         *                   "Id": 18761231234
+         *                 },
+         *                 "SchmeNm": {
+         *                   "Prtry": "MSISDN"
+         *                 }
+         *               }
          *             },
-         *             "Issr": "BIC"
+         *             "CtryOfRes": "BE",
+         *             "CtctDtls": {
+         *               "NmPrfx": "Mr",
+         *               "Nm": "John Doe",
+         *               "PhneNb": "+123-123-321",
+         *               "MobNb": "+123-123-321",
+         *               "FaxNb": "+123-123-321",
+         *               "EmailAdr": "example@example.com"
+         *             }
          *           }
-         *         },
-         *         "RptdDoc": {
-         *           "Nb": 123,
-         *           "RltdDt": "2013-03-07",
-         *           "RltdDtTp": {
-         *             "Cd": 123
-         *           }
-         *         },
-         *         "Rsn": {
-         *           "Cd": 123,
-         *           "Prtry": 123
-         *         }
-         *       },
-         *       "SplmtryData": {
-         *         "PlcAndNm": 123,
-         *         "Envlp": 123,
-         *         "RltdDt": "2013-03-07",
-         *         "RltdDtTp": {
-         *           "Cd": 123
          *         }
          *       }
          *     }
          */
         GetParties_IdentificationVerificationReportV03: {
+            /** @description Assignment
+             *     Identifies the identification assignment.
+             *      */
             Assgnmt: components["schemas"]["IdentificationAssignment3"];
+            /** @description Report
+             *     Information concerning the verification of the identification data for which verification was requested.
+             *      */
             Rpt: components["schemas"]["VerificationReport4"];
+            /** @description SupplementaryData
+             *     Additional information that cannot be captured in the structured elements and/or any other specific block.
+             *      */
             SplmtryData?: components["schemas"]["SupplementaryData1"];
         };
         /**
@@ -2327,8 +2837,17 @@ export interface components {
          */
         IdentificationAssignment3: {
             MsgId: components["schemas"]["Max35Text"];
+            /** @description CreationDateTime
+             *     Date and time at which the identification assignment was created.
+             *      */
             CreDtTm: components["schemas"]["ISODateTime"];
+            /** @description Assignor
+             *     Party that assigns the identification assignment to another party. This is also the sender of the message.
+             *      */
             Assgnr: components["schemas"]["Party40Choice"];
+            /** @description Assignee
+             *     Party that the identification assignment is assigned to. This is also the receiver of the message.
+             *      */
             Assgne: components["schemas"]["Party40Choice"];
         };
         /**
@@ -2357,12 +2876,26 @@ export interface components {
          *     }
          */
         IdentificationInformation4: {
+            /** @description Party
+             *     Account owner that owes an amount of money or to whom an amount of money is due.
+             *      */
             Pty?: components["schemas"]["PartyIdentification135"];
+            /** @description Account
+             *     Unambiguous identification of the account of a party.
+             *      */
             Acct?: components["schemas"]["CashAccount40"];
+            /** @description Agent
+             *     Financial institution servicing an account for a party.
+             *      */
             Agt?: components["schemas"]["BranchAndFinancialInstitutionIdentification6"];
         };
         /**
          * IdentificationVerificationIndicator
+         * @description Definition: Identifies whether the party and/or account information received is correct.
+         *
+         *     • Meaning When True: Indicates that the identification information received is correct.
+         *     • Meaning When False: Indicates that the identification information received is incorrect
+         *
          * @example true
          */
         IdentificationVerificationIndicator: boolean;
@@ -2386,7 +2919,13 @@ export interface components {
          *     }
          */
         InstructionForCreditorAgent3: {
+            /** @description Code
+             *     Coded information related to the processing of the payment instruction, provided by the initiating party, and intended for the creditor's agent.
+             *      */
             Cd?: components["schemas"]["ExternalCreditorAgentInstruction1Code"];
+            /** @description InstructionInformation
+             *     Further information complementing the coded instruction or instruction to the creditor's agent that is bilaterally agreed or specific to a user community.
+             *      */
             InstrInf?: components["schemas"]["Max140Text"];
         };
         /**
@@ -2399,7 +2938,13 @@ export interface components {
          *     }
          */
         InstructionForNextAgent1: {
+            /** @description Code
+             *     Coded information related to the processing of the payment instruction, provided by the initiating party, and intended for the next agent in the payment chain.
+             *      */
             Cd?: components["schemas"]["Instruction4Code"];
+            /** @description InstructionInformation
+             *     Further information complementing the coded instruction or instruction to the next agent that is bilaterally agreed or specific to a user community.
+             *      */
             InstrInf?: components["schemas"]["Max140Text"];
         };
         /**
@@ -2416,7 +2961,13 @@ export interface components {
          *     }
          */
         LocalInstrument2Choice: {
+            /** @description Code
+             *     Specifies the local instrument, as published in an external local instrument code list.
+             *      */
             Cd?: components["schemas"]["ExternalLocalInstrument1Code"];
+            /** @description Proprietary
+             *     Specifies the local instrument, as a proprietary code
+             *      */
             Prtry?: components["schemas"]["Max35Text"];
         } & (unknown | unknown);
         /**
@@ -2539,8 +3090,17 @@ export interface components {
          *     }
          */
         OrganisationIdentification29: {
+            /** @description AnyBIC
+             *     Business identification code of the organisation.
+             *      */
             AnyBIC?: components["schemas"]["AnyBICDec2014Identifier"];
+            /** @description LEI
+             *     Legal entity identification as an alternate identification for a party.
+             *      */
             LEI?: components["schemas"]["LEIIdentifier"];
+            /** @description Other
+             *     Unique identification of an organisation, as assigned by an institution, using an identification scheme.
+             *      */
             Othr?: components["schemas"]["GenericOrganisationIdentification1"];
         };
         /**
@@ -2560,8 +3120,17 @@ export interface components {
          *     }
          */
         OrganisationIdentification39: {
+            /** @description AnyBIC
+             *     Business identification code of the organisation.
+             *      */
             AnyBIC?: components["schemas"]["AnyBICDec2014Identifier"];
+            /** @description LEI
+             *     Legal entity identification as an alternate identification for a party.
+             *      */
             LEI?: components["schemas"]["LEIIdentifier"];
+            /** @description Other
+             *     Unique identification of an organisation, as assigned by an institution, using an identification scheme.
+             *      */
             Othr?: components["schemas"]["GenericOrganisationIdentification3"];
         };
         /**
@@ -2573,7 +3142,13 @@ export interface components {
          *     }
          */
         OrganisationIdentificationSchemeName1Choice: {
+            /** @description Code
+             *     Name of the identification scheme, in a coded form as published in an external list.
+             *      */
             Cd?: components["schemas"]["ExternalOrganisationIdentification1Code"];
+            /** @description Proprietary
+             *     Name of the identification scheme, in a free text form.
+             *      */
             Prtry?: components["schemas"]["Max35Text"];
         } & (unknown | unknown);
         /**
@@ -2586,7 +3161,13 @@ export interface components {
          *     }
          */
         OtherContact1: {
+            /** @description ChannelType
+             *     Method used to contact the financial institution's contact for the specific tax region.
+             *      */
             ChanlTp: components["schemas"]["Max4Text"];
+            /** @description Identifier
+             *     Communication value such as phone number or email address.
+             *      */
             Id?: components["schemas"]["Max128Text"];
         };
         /**
@@ -2758,12 +3339,18 @@ export interface components {
          *     }
          */
         Party38Choice: {
+            /** @description Organisation
+             *     Unique and unambiguous way to identify an organisation.
+             *      */
             OrgId?: components["schemas"]["OrganisationIdentification29"];
+            /** @description PrivateIdentification
+             *     Unique and unambiguous identification of a person, for example a passport.
+             *      */
             PrvtId?: components["schemas"]["PersonIdentification13"];
         } & (unknown | unknown);
         /**
          * Party40Choice
-         * @description Nature or use of the account.
+         * @description Identification of a person, an organisation or a financial institution.
          *
          * @example {
          *       "Pty": {
@@ -2801,12 +3388,18 @@ export interface components {
          *     }
          */
         Party40Choice: {
+            /** @description Party
+             *     Identification of a person or an organisation.
+             *      */
             Pty?: components["schemas"]["PartyIdentification135"];
+            /** @description Agent
+             *     Identification of a financial institution.
+             *      */
             Agt?: components["schemas"]["BranchAndFinancialInstitutionIdentification6"];
         } & (unknown | unknown);
         /**
          * Party52Choice
-         * @description Nature or use of the account.
+         * @description NOTE: Unsure on the description.
          *
          * @example {
          *       "OrgId": {
@@ -2821,7 +3414,13 @@ export interface components {
          *     }
          */
         Party52Choice: {
+            /** @description Organisation
+             *     Unique and unambiguous way to identify an organisation.
+             *      */
             OrgId?: components["schemas"]["OrganisationIdentification39"];
+            /** @description Person
+             *     Unique and unambiguous identification of a person, for example a passport
+             *      */
             PrvtId?: components["schemas"]["PersonIdentification18"];
         } & (unknown | unknown);
         /**
@@ -2831,16 +3430,31 @@ export interface components {
          * @example {
          *       "Nm": "John Doe",
          *       "PstlAdr": {
-         *         "Ctry": "BE",
-         *         "AdrLine": [
-         *           "Rue du Marché 45",
-         *           "Brussels",
-         *           "BE"
-         *         ]
+         *         "AdrTp": "ADDR",
+         *         "Dept": "Dept",
+         *         "SubDept": "SubDept",
+         *         "StrtNm": "StrtNm",
+         *         "BldgNb": "BldgNb",
+         *         "BldgNm": "BldgNm",
+         *         "Flr": "Flr",
+         *         "PstBx": "PstBx",
+         *         "Room": "Room",
+         *         "PstCd": "PstCd",
+         *         "TwnNm": "TwnNm",
+         *         "TwnLctnNm": "TwnLctnNm",
+         *         "DstrctNm": "DstrctNm",
+         *         "CtrySubDvsn": "CtrySubDvsn",
+         *         "Ctry": "Ctry",
+         *         "AdrLine": "AdrLine"
          *       },
          *       "Id": {
          *         "OrgId": {
-         *           "AnyBIC": "CCCCUS33"
+         *           "Othr": {
+         *             "Id": 123,
+         *             "SchmeNm": {
+         *               "Prtry": "DfspId"
+         *             }
+         *           }
          *         }
          *       },
          *       "CtryOfRes": "BE",
@@ -2850,15 +3464,25 @@ export interface components {
          *         "PhneNb": "+123-123-321",
          *         "MobNb": "+123-123-321",
          *         "FaxNb": "+123-123-321",
-         *         "EmailAdr": null
+         *         "EmailAdr": "example@example.com"
          *       }
          *     }
          */
         PartyIdentification135: {
+            /** @description Name by which a party is known and which is usually used to identify that party.
+             *      */
             Nm?: components["schemas"]["Max140Text"];
+            /** @description Information that locates and identifies a specific address, as defined by postal services.
+             *      */
             PstlAdr?: components["schemas"]["PostalAddress24"];
+            /** @description Unique and unambiguous way to identify an organisation.
+             *      */
             Id?: components["schemas"]["Party38Choice"];
+            /** @description Country in which a person resides (the place of a person's home). In the case of a company, it is the country from which the affairs of that company are directed.
+             *      */
             CtryOfRes?: components["schemas"]["CountryCode"];
+            /** @description Set of elements used to indicate how to contact the party.
+             *      */
             CtctDtls?: components["schemas"]["Contact4"];
         };
         /**
@@ -2901,10 +3525,25 @@ export interface components {
          *     }
          */
         PartyIdentification272: {
+            /** @description Name
+             *     Name by which a party is known and which is usually used to identify that party.
+             *      */
             Nm?: components["schemas"]["Max140Text"];
+            /** @description Postal Address
+             *     Information that locates and identifies a specific address, as defined by postal services.
+             *      */
             PstlAdr?: components["schemas"]["PostalAddress27"];
+            /** @description Identification
+             *     Unique and unambiguous identification of a party.
+             *      */
             Id?: components["schemas"]["Party52Choice"];
+            /** @description Country of Residence
+             *     Country in which a person resides (the place of a person's home). In the case of a company, it is the country from which the affairs of that company are directed.
+             *      */
             CtryOfRes?: components["schemas"]["CountryCode"];
+            /** @description Contact Details
+             *     Set of elements used to indicate how to contact the party.
+             *      */
             CtctDtls?: components["schemas"]["Contact13"];
         };
         /**
@@ -2920,10 +3559,30 @@ export interface components {
          *     }
          */
         PaymentIdentification13: {
+            /** @description InstructionIdentification
+             *     Definition: Unique identification, as assigned by an instructing party for an instructed party, to unambiguously identify the instruction.
+             *     Usage: The instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction.
+             *      */
             InstrId?: components["schemas"]["Max35Text"];
+            /** @description EndToEndIdentification
+             *     Definition: Unique identification, as assigned by the initiating party, to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.
+             *     Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.
+             *     Usage: In case there are technical limitations to pass on multiple references, the end-to-end identification must be passed on throughout the entire end-to-end chain.
+             *      */
             EndToEndId: components["schemas"]["Max35Text"];
+            /** @description TransactionIdentification
+             *     Definition: Unique identification, as assigned by the first instructing agent, to unambiguously identify the transaction that is passed on, unchanged, throughout the entire interbank chain.
+             *     Usage: The transaction identification can be used for reconciliation, tracking or to link tasks relating to the transaction on the interbank level.
+             *     Usage: The instructing agent has to make sure that the transaction identification is unique for a preagreed period.
+             *      */
             TxId?: components["schemas"]["Max35Text"];
+            /** @description UETR
+             *     Universally unique identifier to provide an end-to-end reference of a payment transaction.
+             *      */
             UETR?: components["schemas"]["UUIDv4Identifier"];
+            /** @description ClearingSystemReference
+             *     Unique reference, as assigned by a clearing system, to unambiguously identify the instruction.
+             *      */
             ClrSysRef?: components["schemas"]["Max35Text"];
         };
         /**
@@ -2984,10 +3643,26 @@ export interface components {
          *     }
          */
         PaymentTypeInformation28: {
+            /** @description InstructionPriority
+             *     Indicator of the urgency or order of importance that the instructing party would like the instructed party to apply to the processing of the instruction.
+             *      */
             InstrPrty?: components["schemas"]["Priority2Code"];
+            /** @description ClearingChannel
+             *     SSpecifies the clearing channel to be used to process the payment instruction.
+             *      */
             ClrChanl?: components["schemas"]["ClearingChannel2Code"];
+            /** @description ServiceLevel
+             *     Agreement under which or rules under which the transaction should be processed.
+             *      */
             SvcLvl?: components["schemas"]["ServiceLevel8Choice"];
+            /** @description LocalInstrument
+             *     Definition: User community specific instrument.
+             *     Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level.
+             *      */
             LclInstrm?: components["schemas"]["LocalInstrument2Choice"];
+            /** @description CategoryPurpose
+             *     Specifies the high level purpose of the instruction based on a set of pre-defined categories.
+             *      */
             CtgyPurp?: components["schemas"]["CategoryPurpose1Choice"];
         };
         /**
@@ -3014,7 +3689,13 @@ export interface components {
          *     }
          */
         PersonIdentification13: {
+            /** @description DateAndPlaceOfBirth
+             *     Date and place of birth of a person.
+             *      */
             DtAndPlcOfBirth?: components["schemas"]["DateAndPlaceOfBirth1"];
+            /** @description Other
+             *     Unique identification of a person, as assigned by an institution, using an identification scheme.
+             *      */
             Othr?: components["schemas"]["GenericPersonIdentification1"];
         };
         /**
@@ -3036,7 +3717,13 @@ export interface components {
          *     }
          */
         PersonIdentification18: {
+            /** @description DateAndPlaceOfBirth
+             *     Date and place of birth of a person.
+             *      */
             DtAndPlcOfBirth?: components["schemas"]["DateAndPlaceOfBirth1"];
+            /** @description Other
+             *     Unique identification of a person, as assigned by an institution, using an identification scheme.
+             *      */
             Othr?: components["schemas"]["GenericPersonIdentification2"];
         };
         /**
@@ -3048,7 +3735,13 @@ export interface components {
          *     }
          */
         PersonIdentificationSchemeName1Choice: {
+            /** @description Code
+             *     Name of the identification scheme, in a coded form as published in an external list
+             *      */
             Cd?: components["schemas"]["ExternalPersonIdentification1Code"];
+            /** @description Proprietary
+             *     Name of the identification scheme, in a free text form
+             *      */
             Prtry?: components["schemas"]["Max35Text"];
         } & (unknown | unknown);
         /**
@@ -3179,19 +3872,37 @@ export interface components {
          *     }
          */
         ProxyAccountIdentification1: {
+            /** @description Type
+             *
+             *     Type of the proxy identification.
+             *      */
             Tp?: components["schemas"]["ProxyAccountType1Choice"];
+            /** @description Identification
+             *
+             *     Identification used to indicate the account identification under another specified name.
+             *      */
             Id: components["schemas"]["Max2048Text"];
         };
         /**
          * ProxyAccountType1Choice
-         * @description NOTE: Unsure on description.
+         * @description ProxyAccountType1Choice
+         *
+         *     Specifies the scheme used for the identification of an account alias.
          *
          * @example {
          *       "Cd": "CH03"
          *     }
          */
         ProxyAccountType1Choice: {
+            /** @description Code
+             *
+             *     Name of the identification scheme, in a coded form as published in an external list.
+             *      */
             Cd?: components["schemas"]["ExternalProxyAccountType1Code"];
+            /** @description Proprietary
+             *
+             *     Name of the identification scheme, in a free text form.
+             *      */
             Prtry?: components["schemas"]["Max35Text"];
         } & (unknown | unknown);
         /**
@@ -3204,7 +3915,15 @@ export interface components {
          *     }
          */
         Purpose2Choice: {
+            /** @description Code
+             *
+             *     Underlying reason for the payment transaction, as published in an external purpose code list.
+             *      */
             Cd?: components["schemas"]["ExternalPurpose1Code"];
+            /** @description Proprietary
+             *
+             *     Purpose, in a proprietary form.
+             *      */
             Prtry?: components["schemas"]["Max35Text"];
         } & (unknown | unknown);
         /**
@@ -3217,7 +3936,15 @@ export interface components {
          *     }
          */
         RegulatoryAuthority2: {
+            /** @description Name
+             *
+             *     Name of the entity requiring the regulatory reporting information.
+             *      */
             Nm?: components["schemas"]["Max140Text"];
+            /** @description Country
+             *
+             *     Country of the entity that requires the regulatory reporting information.
+             *      */
             Ctry?: components["schemas"]["CountryCode"];
         };
         /**
@@ -3237,9 +3964,19 @@ export interface components {
          *     }
          */
         RegulatoryReporting3: {
+            /** @description DebitCreditReportingIndicator
+             *     Identifies whether the regulatory reporting information applies to the debit side, to the credit side or to both debit and credit sides of the transaction.
+             *      */
             DbtCdtRptgInd?: components["schemas"]["RegulatoryReportingType1Code"];
+            /** @description Authority
+             *
+             *     Entity requiring the regulatory reporting information.
+             *      */
             Authrty?: components["schemas"]["RegulatoryAuthority2"];
-            Dtls?: components["schemas"]["StructuredRegulatoryReporting3"];
+            /** @description Details
+             *     Identifies whether the regulatory reporting information applies to the debit side, to the credit side or to both debit and credit sides of the transaction.
+             *      */
+            Dtls?: components["schemas"]["StructuredRegulatoryReporting3"] | components["schemas"]["StructuredRegulatoryReporting3"][];
         };
         /**
          * RegulatoryReportingType1Code
@@ -3258,12 +3995,19 @@ export interface components {
          *     }
          */
         ServiceLevel8Choice: {
+            /** @description Code
+             *     Specifies a pre-agreed service or level of service between the parties, as published in an external service level code list.
+             *      */
             Cd?: components["schemas"]["ExternalServiceLevel1Code"];
+            /** @description Proprietary
+             *     Specifies a pre-agreed service or level of service between the parties, as a proprietary code.
+             *      */
             Prtry?: components["schemas"]["Max35Text"];
         } & (unknown | unknown);
         /**
          * SettlementInstruction15
-         * @description NOTE: Unsure on description.
+         * @description Specifies the details on how the settlement of the original transaction(s) between the
+         *     instructing agent and the instructed agent was completed.
          *
          * @example {
          *       "SttlmMtd": "INDA",
@@ -3308,7 +4052,12 @@ export interface components {
          *     }
          */
         SettlementInstruction15: {
+            /** @description SettlementMethod
+             *     Method used to settle the (batch of) payment instructions.
+             *      */
             SttlmMtd: components["schemas"]["SettlementMethod1Code"];
+            /** @description PaymentTypeInformation
+             *      */
             PmtTpInf?: components["schemas"]["PaymentTypeInformation28"];
         };
         /**
@@ -3328,7 +4077,13 @@ export interface components {
          *     }
          */
         StatusReason6Choice: {
+            /** @description Code
+             *     Reason for the status, as published in an external reason code list.
+             *      */
             Cd?: components["schemas"]["ExternalStatusReason1Code"];
+            /** @description Proprietary
+             *     Reason for the status, in a proprietary form.
+             *      */
             Prtry?: components["schemas"]["Max35Text"];
         } & (unknown | unknown);
         /**
@@ -3357,13 +4112,21 @@ export interface components {
          *     }
          */
         StatusReasonInformation14: {
+            /** @description Originator
+             *     Party that issues the status. */
             Orgtr?: components["schemas"]["PartyIdentification272"];
+            /** @description Reason
+             *     Specifies the reason for the status report. */
             Rsn?: components["schemas"]["StatusReason6Choice"];
+            /** @description AdditionalInformation
+             *     Additional information about the status report. */
             AddtlInf?: components["schemas"]["Max105Text"];
         };
         /**
          * StructuredRegulatoryReporting3
-         * @description Unsure on description.
+         * @description StructuredRegulatoryReporting3
+         *
+         *     Information needed due to regulatory and statutory requirements.
          *
          * @example {
          *       "Tp": "T1",
@@ -3378,12 +4141,34 @@ export interface components {
          *     }
          */
         StructuredRegulatoryReporting3: {
+            /** @description Type
+             *
+             *     Specifies the type of the information supplied in the regulatory reporting details.
+             *      */
             Tp?: components["schemas"]["Max35Text"];
+            /** @description Date
+             *
+             *     Date related to the specified type of regulatory reporting details.
+             *      */
             Dt?: components["schemas"]["ISODate"];
+            /** @description Country
+             *
+             *     Country related to the specified type of regulatory reporting details.
+             *      */
             Ctry?: components["schemas"]["CountryCode"];
+            /** @description Code
+             *     Specifies the nature, purpose, and reason for the transaction to be reported for regulatory and statutory requirements in a coded form.
+             *      */
             Cd?: components["schemas"]["Max10Text"];
+            /** @description Amount
+             *
+             *     Amount of money to be reported for regulatory and statutory requirements.
+             *      */
             Amt?: components["schemas"]["ActiveOrHistoricCurrencyAndAmount"];
-            Inf?: components["schemas"]["Max35Text"];
+            /** @description Information
+             *     Additional details that cater for specific domestic regulatory requirements.
+             *      */
+            Inf?: components["schemas"]["Max35Text"] | components["schemas"]["Max35Text"][];
         };
         /**
          * SupplementaryData1
@@ -3398,12 +4183,20 @@ export interface components {
          *     }
          */
         SupplementaryData1: {
+            /** @description PlaceAndName
+             *     Unambiguous reference to the location where the supplementary data must be inserted in the message instance.
+             *      */
             PlcAndNm?: components["schemas"]["Max350Text"];
+            /** @description Envelope
+             *     Technical element wrapping the supplementary data.
+             *     Technical component that contains the validated supplementary data information. This technical envelope allows to segregate the supplementary data information from any other information.
+             *      */
             Envlp: components["schemas"]["SupplementaryDataEnvelope1"];
         };
         /**
          * SupplementaryDataEnvelope1
-         * @description Unsure on description.
+         * @description SupplementaryDataEnvelope1
+         *     Technical component that contains the validated supplementary data information. This technical envelope allows to segregate the supplementary data information from any other information.
          *
          */
         SupplementaryDataEnvelope1: Record<string, never>;
@@ -3434,10 +4227,26 @@ export interface components {
          *     }
          */
         TaxAmount3: {
+            /** @description Rate
+             *
+             *     Rate used to calculate the tax.
+             *      */
             Rate?: components["schemas"]["PercentageRate"];
+            /** @description TaxableBaseAmount
+             *
+             *     Amount of money on which the tax is based.
+             *      */
             TaxblBaseAmt?: components["schemas"]["ActiveOrHistoricCurrencyAndAmount"];
+            /** @description TotalAmount
+             *
+             *     Total amount that is the result of the calculation of the tax for the record.
+             *      */
             TtlAmt?: components["schemas"]["ActiveOrHistoricCurrencyAndAmount"];
-            Dtls?: components["schemas"]["TaxRecordDetails3"];
+            /** @description Details
+             *
+             *     Set of elements used to provide details on the tax period and amount.
+             *      */
+            Dtls?: components["schemas"]["TaxRecordDetails3"] | components["schemas"]["TaxRecordDetails3"][];
         };
         /**
          * TaxAuthorisation1
@@ -3449,7 +4258,15 @@ export interface components {
          *     }
          */
         TaxAuthorisation1: {
+            /** @description Title
+             *
+             *     Title or position of debtor or the debtor's authorised representative.
+             *      */
             Titl?: components["schemas"]["Max35Text"];
+            /** @description Name
+             *
+             *     Name of the debtor or the debtor's authorised representative.
+             *      */
             Nm?: components["schemas"]["Max140Text"];
         };
         /**
@@ -3495,17 +4312,61 @@ export interface components {
          *     }
          */
         TaxData1: {
+            /** @description Creditor
+             *
+             *     Party on the credit side of the transaction to which the tax applies.
+             *      */
             Cdtr?: components["schemas"]["TaxParty1"];
+            /** @description Debtor
+             *
+             *     Party on the debit side of the transaction to which the tax applies.
+             *      */
             Dbtr?: components["schemas"]["TaxParty2"];
+            /** @description UltimateDebtor
+             *
+             *     Ultimate party that owes an amount of money to the (ultimate) creditor, in this case, to the taxing authority.
+             *      */
             UltmtDbtr?: components["schemas"]["TaxParty2"];
+            /** @description AdministrationZone
+             *
+             *     Territorial part of a country to which the tax payment is related.
+             *      */
             AdmstnZone?: components["schemas"]["Max35Text"];
+            /** @description ReferenceNumber
+             *
+             *     Tax reference information that is specific to a taxing agency.
+             *      */
             RefNb?: components["schemas"]["Max140Text"];
+            /** @description Method
+             *
+             *     Method used to indicate the underlying business or how the tax is paid.
+             *      */
             Mtd?: components["schemas"]["Max35Text"];
+            /** @description TotalTaxableBaseAmount
+             *
+             *     Total amount of money on which the tax is based.
+             *      */
             TtlTaxblBaseAmt?: components["schemas"]["ActiveOrHistoricCurrencyAndAmount"];
+            /** @description TotalTaxAmount
+             *
+             *     Total amount of money as result of the calculation of the tax.
+             *      */
             TtlTaxAmt?: components["schemas"]["ActiveOrHistoricCurrencyAndAmount"];
+            /** @description Date
+             *
+             *     Date by which tax is due.
+             *      */
             Dt?: components["schemas"]["ISODate"];
+            /** @description SequenceNumber
+             *
+             *     Sequential number of the tax report
+             *      */
             SeqNb?: components["schemas"]["Number"];
-            Rcrd?: components["schemas"]["TaxRecord3"];
+            /** @description Record
+             *
+             *     Details of the tax record.
+             *      */
+            Rcrd?: components["schemas"]["TaxRecord3"] | components["schemas"]["TaxRecord3"][];
         };
         /**
          * TaxParty1
@@ -3518,8 +4379,20 @@ export interface components {
          *     }
          */
         TaxParty1: {
+            /** @description TaxIdentification
+             *
+             *     Tax identification number of the creditor.
+             *      */
             TaxId?: components["schemas"]["Max35Text"];
+            /** @description RegistrationIdentification
+             *
+             *     Unique identification, as assigned by an organisation, to unambiguously identify a party.
+             *      */
             RegnId?: components["schemas"]["Max35Text"];
+            /** @description TaxType
+             *
+             *     Type of tax payer.
+             *      */
             TaxTp?: components["schemas"]["Max35Text"];
         };
         /**
@@ -3537,9 +4410,25 @@ export interface components {
          *     }
          */
         TaxParty2: {
+            /** @description TaxIdentification
+             *
+             *     Tax identification number of the debtor.
+             *      */
             TaxId?: components["schemas"]["Max35Text"];
+            /** @description RegistrationIdentification
+             *
+             *     Unique identification, as assigned by an organisation, to unambiguously identify a party.
+             *      */
             RegnId?: components["schemas"]["Max35Text"];
+            /** @description TaxType
+             *
+             *     Type of tax payer.
+             *      */
             TaxTp?: components["schemas"]["Max35Text"];
+            /** @description Authorisation
+             *
+             *     Details of the authorised tax paying party.
+             *      */
             Authstn?: components["schemas"]["TaxAuthorisation1"];
         };
         /**
@@ -3556,9 +4445,21 @@ export interface components {
          *     }
          */
         TaxPeriod3: {
-            Yr?: components["schemas"]["ISOYear"];
-            Tp?: components["schemas"]["TaxRecordPeriod1Code"];
+            /** @description FromToDate
+             *
+             *     Range of time between a start date and an end date for which the tax report is provided.
+             *      */
             FrToDt?: components["schemas"]["DatePeriod2"];
+            /** @description Type
+             *
+             *     Identification of the period related to the tax payment.
+             *      */
+            Tp?: components["schemas"]["TaxRecordPeriod1Code"];
+            /** @description Year
+             *
+             *     Year related to the tax payment.
+             *      */
+            Yr?: components["schemas"]["ISOYear"];
         };
         /**
          * TaxRecord3
@@ -3584,15 +4485,51 @@ export interface components {
          *     }
          */
         TaxRecord3: {
-            Tp?: components["schemas"]["Max35Text"];
-            Ctgy?: components["schemas"]["Max35Text"];
-            CtgyDtls?: components["schemas"]["Max35Text"];
-            DbtrSts?: components["schemas"]["Max35Text"];
-            CertId?: components["schemas"]["Max35Text"];
-            FrmsCd?: components["schemas"]["Max35Text"];
-            Prd?: components["schemas"]["TaxPeriod3"];
-            TaxAmt?: components["schemas"]["TaxAmount3"];
+            /** @description AdditionalInformation
+             *
+             *     Further details of the tax record.
+             *      */
             AddtlInf?: components["schemas"]["Max140Text"];
+            /** @description CertificateIdentification
+             *
+             *     Identification number of the tax report as assigned by the taxing authority.
+             *      */
+            CertId?: components["schemas"]["Max35Text"];
+            /** @description Category
+             *
+             *     Specifies the tax code as published by the tax authority.
+             *      */
+            Ctgy?: components["schemas"]["Max35Text"];
+            /** @description CategoryDetails
+             *
+             *     Provides further details of the category tax code.
+             *      */
+            CtgyDtls?: components["schemas"]["Max35Text"];
+            /** @description DebtorStatus
+             *
+             *     Code provided by local authority to identify the status of the party that has drawn up the settlement document.
+             *      */
+            DbtrSts?: components["schemas"]["Max35Text"];
+            /** @description FormsCode
+             *
+             *     Identifies, in a coded form, on which template the tax report is to be provided.
+             *      */
+            FrmsCd?: components["schemas"]["Max35Text"];
+            /** @description Period
+             *
+             *     Set of elements used to provide details on the period of time related to the tax payment.
+             *      */
+            Prd?: components["schemas"]["TaxPeriod3"];
+            /** @description TaxAmount
+             *
+             *     Set of elements used to provide information on the amount of the tax record.
+             *      */
+            TaxAmt?: components["schemas"]["TaxAmount3"];
+            /** @description Type
+             *
+             *     High level code to identify the type of tax details.
+             *      */
+            Tp?: components["schemas"]["Max35Text"];
         };
         /**
          * TaxRecordDetails3
@@ -3614,7 +4551,15 @@ export interface components {
          *     }
          */
         TaxRecordDetails3: {
+            /** @description Period
+             *
+             *     Set of elements used to provide details on the period of time related to the tax payment.
+             *      */
             Prd?: components["schemas"]["TaxPeriod3"];
+            /** @description Amount
+             *
+             *     Underlying tax amount related to the specified period.
+             *      */
             Amt: components["schemas"]["ActiveOrHistoricCurrencyAndAmount"];
         };
         /**
@@ -3727,36 +4672,88 @@ export interface components {
          *     }
          */
         VerificationReason1Choice: {
+            /** @description Code
+             *     Reason why the verified identification information is incorrect, as published in an external reason code list.
+             *      */
             Cd?: components["schemas"]["ExternalVerificationReason1Code"];
+            /** @description Proprietary
+             *     Reason why the verified identification information is incorrect, in a free text form.
+             *      */
             Prtry?: components["schemas"]["Max35Text"];
         } & (unknown | unknown);
         /**
          * VerificationReport4
          * @example {
-         *       "OrgnlId": 123456789,
+         *       "OrgnlId": 1.2345678901234568e+33,
          *       "Vrfctn": true,
-         *       "Rsn": {
-         *         "Cd": "AGNT"
-         *       },
          *       "OrgnlPtyAndAcctId": {
-         *         "Id": 123456789,
-         *         "SchmeNm": {
-         *           "Cd": "CCPT"
+         *         "Nm": "John Doe",
+         *         "PstlAdr": {
+         *           "AdrTp": "ADDR",
+         *           "Dept": "Dept",
+         *           "SubDept": "SubDept",
+         *           "StrtNm": "1234 Elm St",
+         *           "BldgNb": 1234,
+         *           "PstCd": 12345,
+         *           "TwnNm": "Anytown",
+         *           "CtrySubDvsn": "CA",
+         *           "Ctry": "US"
+         *         },
+         *         "Id": {
+         *           "OrgId": {
+         *             "AnyBIC": "ABCDUS33",
+         *             "Othr": {
+         *               "Id": 123456789,
+         *               "Issr": "ABA"
+         *             }
+         *           }
          *         }
          *       },
          *       "UpdtdPtyAndAcctId": {
-         *         "Id": 123456789,
-         *         "SchmeNm": {
-         *           "Cd": "CCPT"
+         *         "Nm": "John Doe",
+         *         "PstlAdr": {
+         *           "AdrTp": "ADDR",
+         *           "Dept": "Dept",
+         *           "SubDept": "SubDept",
+         *           "StrtNm": "1234 Elm St",
+         *           "BldgNb": 1234,
+         *           "PstCd": 12345,
+         *           "TwnNm": "Anytown",
+         *           "CtrySubDvsn": "CA",
+         *           "Ctry": "US"
+         *         },
+         *         "Id": {
+         *           "OrgId": {
+         *             "AnyBIC": "ABCDUS33",
+         *             "Othr": {
+         *               "Id": 123456789,
+         *               "Issr": "ABA"
+         *             }
+         *           }
          *         }
          *       }
          *     }
          */
         VerificationReport4: {
+            /** @description OriginalIdentification
+             *     Unique identification, as assigned by a sending party, to unambiguously identify the party and account identification information group within the original message.
+             *      */
             OrgnlId: components["schemas"]["Max35Text"];
+            /** @description Verification
+             *     Identifies whether the party and/or account information received is correct. Boolean value.
+             *      */
             Vrfctn: components["schemas"]["IdentificationVerificationIndicator"];
+            /** @description Reason.
+             *     Specifies the reason why the verified identification information is incorrect.
+             *      */
             Rsn?: components["schemas"]["VerificationReason1Choice"];
+            /** @description OriginalPartyAndAccountIdentification
+             *     Provides party and/or account identification information as given in the original message.
+             *      */
             OrgnlPtyAndAcctId?: components["schemas"]["IdentificationInformation4"];
+            /** @description UpdatedPartyAndAccountIdentification
+             *     Provides party and/or account identification information.
+             *      */
             UpdtdPtyAndAcctId?: components["schemas"]["IdentificationInformation4"];
         };
         /**

--- a/src/fspiop/v2_0_ISO20022/openapi.ts
+++ b/src/fspiop/v2_0_ISO20022/openapi.ts
@@ -801,7 +801,7 @@ export interface components {
          *     }
          */
         BranchData5: {
-            /** @description identification
+            /** @description Identification
              *     Unique and unambiguous identification of a branch of a financial institution.
              *      */
             Id?: components["schemas"]["Max35Text"];
@@ -1290,9 +1290,7 @@ export interface components {
              *      */
             ChrgBr: components["schemas"]["ChargeBearerType1Code"];
             /** @description ChargesInformation
-             *
-             *      Provides information on the charges to be paid by the charge bearer(s) related to the
-             *     payment transaction
+             *     Provides information on the charges to be paid by the charge bearer(s) related to the payment transaction
              *      */
             ChrgsInf?: components["schemas"]["Charges16"];
             /** @description Debtor
@@ -1894,132 +1892,113 @@ export interface components {
          * FxRequest_FICreditTransferProposal
          * @example {
          *       "GrpHdr": {
-         *         "MsgId": 123456789,
+         *         "MsgId": 12345,
          *         "CreDtTm": "2020-01-01T00:00:00Z",
          *         "NbOfTxs": 1,
-         *         "CtrlSum": 100,
-         *         "InitgPty": {
-         *           "Nm": "Initiating Party Name",
-         *           "Id": {
-         *             "OrgId": {
-         *               "Othr": [
-         *                 {
-         *                   "Id": 123456789,
-         *                   "SchmeNm": {
-         *                     "Cd": "BIC"
-         *                   }
-         *                 }
-         *               ]
-         *             }
-         *           }
+         *         "TtlIntrBkSttlmAmt": {
+         *           "Ccy": "EUR",
+         *           "Value": 100
          *         },
-         *         "FwdgAgt": {
-         *           "FinInstnId": {
-         *             "BICFI": "BICFID0"
-         *           }
-         *         },
-         *         "Dbtr": {
-         *           "Nm": "Debtor Name",
-         *           "PstlAdr": {
-         *             "AdrLine": [
-         *               "Debtor Address Line 1",
-         *               "Debtor Address Line 2"
-         *             ]
-         *           },
-         *           "Id": {
-         *             "OrgId": {
-         *               "Othr": [
-         *                 {
-         *                   "Id": 123456789,
-         *                   "SchmeNm": {
-         *                     "Cd": "BIC"
-         *                   }
-         *                 }
-         *               ]
-         *             }
-         *           }
-         *         },
-         *         "DbtrAcct": {
-         *           "Id": {
-         *             "IBAN": "BE71096123456769"
-         *           }
-         *         },
-         *         "DbtrAgt": {
-         *           "FinInstnId": {
-         *             "BICFI": "BICFID0"
-         *           }
-         *         },
-         *         "Cdtr": {
-         *           "Nm": "Creditor Name",
-         *           "PstlAdr": {
-         *             "AdrLine": [
-         *               "Creditor Address Line 1",
-         *               "Creditor Address Line 2"
-         *             ]
-         *           },
-         *           "Id": {
-         *             "OrgId": {
-         *               "Othr": [
-         *                 {
-         *                   "Id": 123456789,
-         *                   "SchmeNm": {
-         *                     "Cd": "BIC"
-         *                   }
-         *                 }
-         *               ]
-         *             }
-         *           }
-         *         },
-         *         "CdtrAcct": {
-         *           "Id": {
-         *             "IBAN": "BE71096123456769"
-         *           }
-         *         },
-         *         "CdtrAgt": {
-         *           "FinInstnId": {
-         *             "BICFI": "BICFID0"
-         *           }
-         *         },
-         *         "CdtTrfTxInf": [
-         *           {
-         *             "PmtId": {
-         *               "InstrId": 123456789,
-         *               "EndToEndId": 123456789
+         *         "SttlmInf": {
+         *           "SttlmMtd": "INDA",
+         *           "SttlmAcct": {
+         *             "Id": {
+         *               "IBAN": "BE71096123456769"
          *             },
-         *             "Amt": {
-         *               "InstdAmt": {
-         *                 "Ccy": "EUR",
-         *                 "Amt": 100
-         *               }
+         *             "Ccy": "EUR"
+         *           },
+         *           "SttlmAcctOwnr": {
+         *             "Nm": "Name"
+         *           },
+         *           "SttlmAcctSvcr": {
+         *             "Nm": "Name"
+         *           },
+         *           "SttlmAgt": {
+         *             "FinInstnId": {
+         *               "BICFI": "BIC"
+         *             }
+         *           }
+         *         },
+         *         "PmtTpInf": {
+         *           "InstrPrty": "NORM",
+         *           "CtgyPurp": "CASH"
+         *         },
+         *         "CdtTrfTxInf": {
+         *           "PmtId": {
+         *             "InstrId": 12345,
+         *             "EndToEndId": 12345
+         *           },
+         *           "Amt": {
+         *             "InstdAmt": {
+         *               "Ccy": "EUR",
+         *               "Value": 100
+         *             }
+         *           },
+         *           "Cdtr": {
+         *             "Nm": "Name"
+         *           },
+         *           "CdtrAcct": {
+         *             "Id": {
+         *               "IBAN": "BE71096123456769"
          *             },
-         *             "CdtrAgt": {
+         *             "Ccy": "EUR"
+         *           },
+         *           "CdtrAgt": {
+         *             "FinInstnId": {
+         *               "BICFI": "BIC"
+         *             }
+         *           },
+         *           "Dbtr": {
+         *             "Nm": "Name"
+         *           },
+         *           "DbtrAcct": {
+         *             "Id": {
+         *               "IBAN": "BE71096123456769"
+         *             },
+         *             "Ccy": "EUR"
+         *           },
+         *           "DbtrAgt": {
+         *             "FinInstnId": {
+         *               "BICFI": "BIC"
+         *             }
+         *           },
+         *           "IntrBkSttlmAmt": {
+         *             "Ccy": "EUR",
+         *             "Value": 100
+         *           },
+         *           "PmtTpInf": {
+         *             "InstrPrty": "NORM",
+         *             "ClrChanl": "RTGS",
+         *             "SvcLvl": {
+         *               "Cd": "SEPA"
+         *             },
+         *             "LclInstrm": {
+         *               "Cd": "CORE"
+         *             },
+         *             "CtgyPurp": {
+         *               "Cd": "CASH"
+         *             }
+         *           },
+         *           "RgltryRptg": {
+         *             "Dbtr": {
+         *               "Nm": "Name"
+         *             },
+         *             "DbtrAcct": {
+         *               "Id": {
+         *                 "IBAN": "BE71096123456769"
+         *               },
+         *               "Ccy": "EUR"
+         *             },
+         *             "DbtrAgt": {
          *               "FinInstnId": {
-         *                 "BICFI": "BICFID0"
+         *                 "BICFI": "BIC"
          *               }
          *             },
          *             "Cdtr": {
-         *               "Nm": "Creditor Name",
-         *               "PstlAdr": {
-         *                 "AdrLine": [
-         *                   "Creditor Address Line 1",
-         *                   "Creditor Address Line 2"
-         *                 ]
-         *               },
-         *               "Id": {
-         *                 "OrgId": {
-         *                   "Othr": [
-         *                     {
-         *                       "Id": 123456789,
-         *                       "SchmeNm": {
-         *                         "Cd": "BIC"
-         *                       }
-         *                     }
-         *                   ]
-         *                 }
-         *               }
+         *               "Nm": "Name"
          *             }
          *           }
-         *         ]
+         *         }
          *       }
          *     }
          */
@@ -2693,8 +2672,19 @@ export interface components {
          *     }
          */
         GroupHeader120: {
+            /** @description MessageIdentification
+             *     Definition: Point to point reference, as assigned by the instructing party, and sent to the next party in the chain to unambiguously identify the message.
+             *     Usage: The instructing party has to make sure that MessageIdentification is unique per instructed party for a pre-agreed period.
+             *      */
             MsgId: components["schemas"]["Max35Text"];
+            /** @description CreationDateTime
+             *     Date and time at which the message was created.
+             *      */
             CreDtTm: components["schemas"]["ISODateTime"];
+            /** @description TransactionInformationAndStatus
+             *     Definition: Agent that instructs the next party in the chain to carry out the (set of) instruction(s).
+             *     Usage: The instructing agent is the party sending the status message and not the party that sent the original instruction that is being reported on.
+             *      */
             TxInfAndSts?: components["schemas"]["PaymentTransaction163"];
         };
         /**
@@ -3218,103 +3208,27 @@ export interface components {
          *
          * @example {
          *       "GrpHdr": {
-         *         "MsgId": 123,
+         *         "MsgId": 12345,
          *         "CreDtTm": "2020-01-01T00:00:00Z",
-         *         "NbOfTxs": 1,
-         *         "SttlmInf": {
-         *           "SttlmMtd": "INDA",
-         *           "SttlmDt": "2020-01-01",
-         *           "SttlmTmIndctn": "RTGS",
-         *           "SttlmTmReq": "2020-01-01T00:00:00Z",
-         *           "SttlmAcct": {
-         *             "Id": {
-         *               "Othr": {
-         *                 "Id": 123,
-         *                 "SchmeNm": {
-         *                   "Cd": "IBAN"
-         *                 },
-         *                 "Issr": "BIC"
-         *               }
-         *             }
-         *           },
-         *           "ClrSys": {
-         *             "Prtry": 123
-         *           },
-         *           "InstgAgt": {
-         *             "FinInstnId": {
-         *               "BICFI": 123
-         *             }
-         *           },
-         *           "InstdAgt": {
-         *             "FinInstnId": {
-         *               "BICFI": 123
-         *             }
-         *           }
-         *         },
-         *         "InstgAgt": {
-         *           "FinInstnId": {
-         *             "BICFI": 123
-         *           }
-         *         },
-         *         "InstdAgt": {
-         *           "FinInstnId": {
-         *             "BICFI": 123
-         *           }
-         *         },
-         *         "IntrBkSttlmAmt": {
-         *           "Amt": 123,
-         *           "Ccy": "EUR"
-         *         },
-         *         "IntrBkSttlmDt": "2020-01-01",
-         *         "TxSts": "ACCP",
-         *         "StsRsnInf": {
-         *           "Orgtr": {
-         *             "Id": {
-         *               "Othr": {
-         *                 "Id": 123,
-         *                 "SchmeNm": {
-         *                   "Cd": "IBAN"
-         *                 },
-         *                 "Issr": "BIC"
-         *               }
-         *             }
-         *           },
-         *           "Rsn": {
-         *             "Cd": 123,
-         *             "Prtry": 123
-         *           }
-         *         },
          *         "TxInfAndSts": {
-         *           "OrgnlInstrId": 123,
-         *           "OrgnlEndToEndId": 123,
-         *           "TxSts": "ACCP",
+         *           "StsId": 12345,
+         *           "OrgnlInstrId": 12345,
+         *           "OrgnlEndToEndId": 12345,
+         *           "OrgnlTxId": 12345,
+         *           "OrgnlUETR": "123e4567-e89b-12d3-a456-426614174000",
+         *           "TxSts": "RJCT",
          *           "StsRsnInf": {
-         *             "Orgtr": {
-         *               "Id": {
-         *                 "Othr": {
-         *                   "Id": 123,
-         *                   "SchmeNm": {
-         *                     "Cd": "IBAN"
-         *                   },
-         *                   "Issr": "BIC"
-         *                 }
-         *               }
-         *             },
-         *             "Rsn": {
-         *               "Cd": 123,
-         *               "Prtry": 123
-         *             }
+         *             "Rsn": "RSN",
+         *             "AddtlInf": "ADDITIONAL"
          *           },
-         *           "ChrgsInf": {
-         *             "Amt": 123,
-         *             "Ccy": "EUR"
-         *           },
-         *           "IntrBkSttlmAmt": {
-         *             "Amt": 123,
-         *             "Ccy": "EUR"
-         *           },
-         *           "IntrBkSttlmDt": "2020-01-01",
-         *           "SttlmTmIndctn": "RTGS"
+         *           "AccptncDtTm": "2020-01-01T00:00:00Z",
+         *           "AcctSvcrRef": "ACCTSVCRREF",
+         *           "ClrSysRef": "CLRSYSREF",
+         *           "ExctnConf": "1234567890ABCDEF",
+         *           "SplmtryData": {
+         *             "PlcAndNm": "PLACE",
+         *             "Envlp": "ENVELOPE"
+         *           }
          *         }
          *       }
          *     }
@@ -3469,19 +3383,23 @@ export interface components {
          *     }
          */
         PartyIdentification135: {
-            /** @description Name by which a party is known and which is usually used to identify that party.
+            /** @description Name
+             *     Name by which a party is known and which is usually used to identify that party.
              *      */
             Nm?: components["schemas"]["Max140Text"];
-            /** @description Information that locates and identifies a specific address, as defined by postal services.
+            /** @description PostalAddress
+             *     Information that locates and identifies a specific address, as defined by postal services.
              *      */
             PstlAdr?: components["schemas"]["PostalAddress24"];
-            /** @description Unique and unambiguous way to identify an organisation.
+            /** @description Identification
+             *     Unique and unambiguous way to identify an organisation.
              *      */
             Id?: components["schemas"]["Party38Choice"];
-            /** @description Country in which a person resides (the place of a person's home). In the case of a company, it is the country from which the affairs of that company are directed.
+            /** @description CountryOfResidence Country in which a person resides (the place of a person's home). In the case of a company, it is the country from which the affairs of that company are directed.
              *      */
             CtryOfRes?: components["schemas"]["CountryCode"];
-            /** @description Set of elements used to indicate how to contact the party.
+            /** @description ContactDetails
+             *     Set of elements used to indicate how to contact the party.
              *      */
             CtctDtls?: components["schemas"]["Contact4"];
         };
@@ -3648,7 +3566,7 @@ export interface components {
              *      */
             InstrPrty?: components["schemas"]["Priority2Code"];
             /** @description ClearingChannel
-             *     SSpecifies the clearing channel to be used to process the payment instruction.
+             *     Specifies the clearing channel to be used to process the payment instruction.
              *      */
             ClrChanl?: components["schemas"]["ClearingChannel2Code"];
             /** @description ServiceLevel


### PR DESCRIPTION
- Update to openapi 3.1.0 to support `description` on the same level as `$ref`. This is important for the readability of the api since it uses shorthand properties that can have different meanings depending on the parent component.
- Fix some copilot examples (tackle this as we go since it's tedium)
- Add descriptions where possible.
- Include full titles for what shorthand represents.