### PR TITLE
fix(pisp): reduce minimum length for WebAuthn attestationObject

### DIFF
--- a/thirdparty/v2_0/openapi3/components/schemas/AuthenticatorAttestationResponse.yaml
+++ b/thirdparty/v2_0/openapi3/components/schemas/AuthenticatorAttestationResponse.yaml
@@ -15,7 +15,7 @@ properties:
     type: string
     description: |
       CBOR.encoded attestation object
-    minLength: 306
+    minLength: 238
     maxLength: 2048
 required:
   - clientDataJSON

--- a/thirdparty/v2_0/openapi3/components/schemas/FIDOPublicKeyCredentialAttestation.yaml
+++ b/thirdparty/v2_0/openapi3/components/schemas/FIDOPublicKeyCredentialAttestation.yaml
@@ -36,7 +36,7 @@ properties:
         type: string
         description: |
           CBOR.encoded attestation object
-        minLength: 306
+        minLength: 238
         maxLength: 2048
     required:
       - clientDataJSON

--- a/thirdparty/v2_0/openapi3/thirdparty-dfsp-admin-api.yaml
+++ b/thirdparty/v2_0/openapi3/thirdparty-dfsp-admin-api.yaml
@@ -1435,7 +1435,7 @@ paths:
                                   type: string
                                   description: |
                                     CBOR.encoded attestation object
-                                  minLength: 306
+                                  minLength: 238
                                   maxLength: 2048
                               required:
                                 - clientDataJSON

--- a/thirdparty/v2_0/openapi3/thirdparty-pisp-admin-api.yaml
+++ b/thirdparty/v2_0/openapi3/thirdparty-pisp-admin-api.yaml
@@ -1580,7 +1580,7 @@ paths:
                                   type: string
                                   description: |
                                     CBOR.encoded attestation object
-                                  minLength: 306
+                                  minLength: 238
                                   maxLength: 2048
                               required:
                                 - clientDataJSON


### PR DESCRIPTION
## Description
This PR addresses strict schema verification constraints within the PISP v2.0 domain that cause valid mobile passkey registrations to fail. 

Specifically, this change:
- Reduces the `minLength` for `attestationObject` to `238`. This accommodates the unpadded Base64url encoded payloads generated by Android (178 bytes → 238 characters) and iOS (182 bytes → 243 characters) devices.

## Related Issue
Resolves mojaloop/project#4378